### PR TITLE
Add pool_pre_ping to sqlalchemy engine creation

### DIFF
--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -71,7 +71,7 @@ class SqlAlchemyStore(AbstractStore):
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.artifact_root_uri = default_artifact_root
-        self.engine = sqlalchemy.create_engine(db_uri)
+        self.engine = sqlalchemy.create_engine(db_uri, pool_pre_ping=True)
         insp = sqlalchemy.inspect(self.engine)
         # On a completely fresh MLflow installation against an empty database (verify database
         # emptiness by checking that 'experiments' etc aren't in the list of table names), run all

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -124,7 +124,7 @@ def test_get_store_sqlalchemy_store(tmp_wkdir, db_type):
         assert store.db_uri == uri
         assert store.artifact_root_uri == "./mlruns"
 
-    mock_create_engine.assert_called_once_with(uri)
+    mock_create_engine.assert_called_once_with(uri, pool_pre_ping=True)
 
 
 @pytest.mark.parametrize("db_type", DATABASE_ENGINES)
@@ -144,7 +144,7 @@ def test_get_store_sqlalchemy_store_with_artifact_uri(tmp_wkdir, db_type):
         assert store.db_uri == uri
         assert store.artifact_root_uri == artifact_uri
 
-    mock_create_engine.assert_called_once_with(uri)
+    mock_create_engine.assert_called_once_with(uri, pool_pre_ping=True)
 
 
 def test_get_store_databricks():


### PR DESCRIPTION
Add pool_pre_ping to engine creation in order to be more robust on database disconnection
It fixes the  'MySQL server has gone away' error that comes from time to time.
This error can come to disconnection from server due a restart of the DB, a timeout initiated from DB, etc.

Documentation from sqlalchemy: https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic

## What changes are proposed in this pull request?
 
Add pool_pre_ping option in create_engine. This option tests connection with a 'Select 1' request before any DB query.
 
## How is this patch tested?
1/ Instantiate a SqlAlchemyStore
2/ List experiment => Connection is open
3/ In the mariadb administration, kill connection
4/ List experiment => It works (without change, it creates a 'MySQL has gone away' error)
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
