### PR TITLE
[front] Allow to link to gerrit project

### DIFF
--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -126,10 +126,15 @@ class Utils {
     return /[@/]bitbucket.org[:/]([^/.]+)\/([^/#]+)#?(.*)/;
   }
 
+  static getGerritRegex() {
+    return /[@/]review.crto.in[:/](\d*)\/([\w\W]+)/;
+  }
+
   static getGitRepoUrl(sourceName) {
     const gitHubMatch = sourceName.match(Utils.getGitHubRegex());
     const gitLabMatch = sourceName.match(Utils.getGitLabRegex());
     const bitbucketMatch = sourceName.match(Utils.getBitbucketRegex());
+    const gerritMatch = sourceName.match(Utils.getGerritRegex());
     let url = null;
     if (gitHubMatch || gitLabMatch) {
       const baseUrl = gitHubMatch ? "https://github.com/" : "https://gitlab.com/";
@@ -144,6 +149,8 @@ class Utils {
       if (bitbucketMatch[3]) {
         url = url + "/src/master/" + bitbucketMatch[3];
       }
+    } else if (gerritMatch) {
+        url = "https://review.crto.in/gitweb?p=" + gerritMatch[2];
     }
     return url;
   }
@@ -152,6 +159,7 @@ class Utils {
     const gitHubMatch = sourceName.match(Utils.getGitHubRegex());
     const gitLabMatch = sourceName.match(Utils.getGitLabRegex());
     const bitbucketMatch = sourceName.match(Utils.getBitbucketRegex());
+    const gerritMatch = sourceName.match(Utils.getGerritRegex());
     let url = null;
     if (gitHubMatch || gitLabMatch) {
       const baseUrl = gitHubMatch ? "https://github.com/" : "https://gitlab.com/";
@@ -162,6 +170,8 @@ class Utils {
       const baseUrl = "https://bitbucket.org/";
       url = (baseUrl + bitbucketMatch[1] + "/" + bitbucketMatch[2].replace(/.git/, '') +
             "/src/" + sourceVersion) + "/" + bitbucketMatch[3];
+    } else if (gerritMatch) {
+        url = "https://review.crto.in/gitweb?p=" + gerritMatch[2] + ";a=commit;h=" + sourceVersion;
     }
     return url;
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Make links to project / revision compatible with Criteo Gerrit
 
## How is this patch tested?
 
Tested in fronted
 
## Release Notes
 
### Is this a user-facing change? 

- [x] Yes. When using a Gerrit format url, makes links clickable
