### PR TITLE
Remove .dev0 from version because it break pex build

### DIFF
--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 
-VERSION = '1.3.1.dev0'
+VERSION = '1.3.1'


### PR DESCRIPTION
In order to fix pex build