### PR TITLE
Inject size of the sqlalchemy pool

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -165,10 +165,15 @@ def _upgrade_db_initialized_before_mlflow_1(url):
 
 
 def create_sqlalchemy_engine(db_uri):
-    pool_size = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, "2"))
-    pool_max_overflow = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW, "0"))
+    pool_size = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, ""))
+    pool_max_overflow = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW, ""))
     _logger.info("Create SQLAlchemy engine with pool_size=%d, max_overflow=%d",
                  pool_size, pool_max_overflow)
+    pool_kwargs = {}
+    # Send argument only if they have been injected. Some engine does not support them (for example sqllite)
+    if pool_size:
+        pool_kwargs['pool_size'] = pool_size
+    if pool_max_overflow:
+        pool_kwargs['max_overflow'] = pool_max_overflow
     return sqlalchemy.create_engine(db_uri, pool_pre_ping=True,
-                                    pool_size=pool_size,
-                                    max_overflow=pool_max_overflow)
+                                    **pool_kwargs)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -14,6 +14,10 @@ from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
 _logger = logging.getLogger(__name__)
 
 
+MLFLOW_SQLALCHEMYSTORE_POOL_SIZE = "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE"
+MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW"
+
+
 def _get_package_dir():
     """Returns directory containing MLflow python package."""
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -158,3 +162,13 @@ def _upgrade_db_initialized_before_mlflow_1(url):
     # add metric steps, do not need to depend on this one. This allows us to eventually remove this
     # method and the associated migration e.g. in MLflow 1.1.
     command.stamp(config, "base")
+
+
+def create_sqlalchemy_engine(db_uri):
+    pool_size = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, "2"))
+    pool_max_overflow = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW, "0"))
+    _logger.info("Create SQLAlchemy engine with pool_size=%d, max_overflow=%d",
+                 pool_size, pool_max_overflow)
+    return sqlalchemy.create_engine(db_uri, pool_pre_ping=True,
+                                    pool_size=pool_size,
+                                    max_overflow=pool_max_overflow)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -165,15 +165,14 @@ def _upgrade_db_initialized_before_mlflow_1(url):
 
 
 def create_sqlalchemy_engine(db_uri):
-    pool_size = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, ""))
-    pool_max_overflow = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW, ""))
-    _logger.info("Create SQLAlchemy engine with pool_size=%d, max_overflow=%d",
-                 pool_size, pool_max_overflow)
+    pool_size = os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, "")
+    pool_max_overflow = os.environ.get(MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW, "")
     pool_kwargs = {}
     # Send argument only if they have been injected. Some engine does not support them (for example sqllite)
     if pool_size:
-        pool_kwargs['pool_size'] = pool_size
+        pool_kwargs['pool_size'] = int(pool_size)
     if pool_max_overflow:
-        pool_kwargs['max_overflow'] = pool_max_overflow
+        pool_kwargs['max_overflow'] = int(pool_max_overflow)
+    _logger.info("Create SQLAlchemy engine with pool options % s", pool_kwargs)
     return sqlalchemy.create_engine(db_uri, pool_pre_ping=True,
                                     **pool_kwargs)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -168,7 +168,8 @@ def create_sqlalchemy_engine(db_uri):
     pool_size = os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, "")
     pool_max_overflow = os.environ.get(MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW, "")
     pool_kwargs = {}
-    # Send argument only if they have been injected. Some engine does not support them (for example sqllite)
+    # Send argument only if they have been injected.
+    # Some engine does not support them (for example sqllite)
     if pool_size:
         pool_kwargs['pool_size'] = int(pool_size)
     if pool_max_overflow:

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -1,7 +1,6 @@
 import time
 
 import logging
-import os
 import sqlalchemy
 
 from mlflow.entities.model_registry.model_version_stages import get_canonical_stage, \
@@ -26,8 +25,6 @@ _logger = logging.getLogger(__name__)
 # https://docs.sqlalchemy.org/en/latest/orm/mapping_api.html#sqlalchemy.orm.configure_mappers
 # and https://docs.sqlalchemy.org/en/latest/orm/mapping_api.html#sqlalchemy.orm.mapper.Mapper
 sqlalchemy.orm.configure_mappers()
-
-MLFLOW_SQLALCHEMYSTORE_POOL_SIZE = "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE"
 
 
 def now():
@@ -67,10 +64,7 @@ class SqlAlchemyStore(AbstractStore):
         super(SqlAlchemyStore, self).__init__()
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
-        pool_size = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, "2"))
-        _logger.info("Create SQLAlchemy engine with pool_size=%d", pool_size)
-        self.engine = sqlalchemy.create_engine(db_uri, pool_pre_ping=True,
-                                               pool_size=pool_size, max_overflow=0)
+        self.engine = mlflow.store.db.utils.create_sqlalchemy_engine(db_uri)
         Base.metadata.create_all(self.engine)
         # Verify that all model registry tables exist.
         SqlAlchemyStore._verify_registry_tables_exist(self.engine)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -1,6 +1,7 @@
 import time
 
 import logging
+import os
 import sqlalchemy
 
 from mlflow.entities.model_registry.model_version_stages import get_canonical_stage, \
@@ -25,6 +26,8 @@ _logger = logging.getLogger(__name__)
 # https://docs.sqlalchemy.org/en/latest/orm/mapping_api.html#sqlalchemy.orm.configure_mappers
 # and https://docs.sqlalchemy.org/en/latest/orm/mapping_api.html#sqlalchemy.orm.mapper.Mapper
 sqlalchemy.orm.configure_mappers()
+
+MLFLOW_SQLALCHEMYSTORE_POOL_SIZE = "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE"
 
 
 def now():
@@ -64,7 +67,10 @@ class SqlAlchemyStore(AbstractStore):
         super(SqlAlchemyStore, self).__init__()
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
-        self.engine = sqlalchemy.create_engine(db_uri, pool_pre_ping=True)
+        pool_size = int(os.environ.get(MLFLOW_SQLALCHEMYSTORE_POOL_SIZE, "2"))
+        _logger.info("Create SQLAlchemy engine with pool_size=%d", pool_size)
+        self.engine = sqlalchemy.create_engine(db_uri, pool_pre_ping=True,
+                                               pool_size=pool_size, max_overflow=0)
         Base.metadata.create_all(self.engine)
         # Verify that all model registry tables exist.
         SqlAlchemyStore._verify_registry_tables_exist(self.engine)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -77,7 +77,7 @@ class SqlAlchemyStore(AbstractStore):
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.artifact_root_uri = default_artifact_root
-        self.engine = sqlalchemy.create_engine(db_uri, pool_pre_ping=True)
+        self.engine = mlflow.store.db.utils.create_sqlalchemy_engine(db_uri)
         # On a completely fresh MLflow installation against an empty database (verify database
         # emptiness by checking that 'experiments' etc aren't in the list of table names), run all
         # DB migrations


### PR DESCRIPTION
## What changes are proposed in this pull request?

A new env variable to control the sqlalchemy pool size

## How is this patch tested?

By running server with 17 workers on mariadb that accepts 50 connections. Using a pool_size=2, we don't experience "too many connections"

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
