### PR TITLE
Add a list_all_columns function to store and handler

### DIFF
--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -4,6 +4,7 @@ The ``mlflow.entities`` module defines entities returned by the MLflow
 """
 
 from mlflow.entities.experiment import Experiment
+from mlflow.entities.columns import Columns
 from mlflow.entities.experiment_tag import ExperimentTag
 from mlflow.entities.file_info import FileInfo
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -19,6 +20,7 @@ from mlflow.entities.view_type import ViewType
 
 __all__ = [
     "Experiment",
+    "Columns",
     "FileInfo",
     "Metric",
     "Param",

--- a/mlflow/entities/columns.py
+++ b/mlflow/entities/columns.py
@@ -1,0 +1,51 @@
+from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.protos.service_pb2 import ListAllColumns
+
+
+class Columns(_MLflowObject):
+    """
+    Columns object.
+    """
+
+    def __init__(self, metrics, params, tags, attributes=None):
+        if attributes is None:
+            attributes = ["run_uuid", "experiment_id", "user_id",
+                          "status", "start_time", "end_time",
+                          "lifecycle_stage", "artifact_uri", "run_id"]
+        super(Columns, self).__init__()
+        self._attributes = attributes
+        self._metrics = metrics
+        self._params = params
+        self._tags = tags
+
+    @property
+    def attributes(self):
+        return self._attributes
+
+    @property
+    def metrics(self):
+        return self._metrics
+
+    @property
+    def params(self):
+        return self._params
+
+    @property
+    def tags(self):
+        return self._tags
+
+    @classmethod
+    def from_proto(cls, proto):
+        columns = cls(proto.attributes,
+                      proto.metrics,
+                      proto.params,
+                      proto.tags)
+        return columns
+
+    def to_proto(self):
+        columns = ListAllColumns.Response()
+        columns.attributes.extend(self.attributes)
+        columns.metrics.extend(self.metrics)
+        columns.params.extend(self.params)
+        columns.tags.extend(self.tags)
+        return columns

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -34685,6 +34685,1844 @@ public final class Service {
 
   }
 
+  public interface ListAllColumnsOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.ListAllColumns)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    java.util.List<java.lang.String>
+        getExperimentIdsList();
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    int getExperimentIdsCount();
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    java.lang.String getExperimentIds(int index);
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getExperimentIdsBytes(int index);
+  }
+  /**
+   * Protobuf type {@code mlflow.ListAllColumns}
+   */
+  public  static final class ListAllColumns extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.ListAllColumns)
+      ListAllColumnsOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ListAllColumns.newBuilder() to construct.
+    private ListAllColumns(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ListAllColumns() {
+      experimentIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ListAllColumns(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                experimentIds_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              experimentIds_.add(bs);
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          experimentIds_ = experimentIds_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.Service.ListAllColumns.class, org.mlflow.api.proto.Service.ListAllColumns.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.ListAllColumns.Response)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      java.util.List<java.lang.String>
+          getAttributesList();
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      int getAttributesCount();
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      java.lang.String getAttributes(int index);
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      com.google.protobuf.ByteString
+          getAttributesBytes(int index);
+
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      java.util.List<java.lang.String>
+          getMetricsList();
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      int getMetricsCount();
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      java.lang.String getMetrics(int index);
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      com.google.protobuf.ByteString
+          getMetricsBytes(int index);
+
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      java.util.List<java.lang.String>
+          getParamsList();
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      int getParamsCount();
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      java.lang.String getParams(int index);
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      com.google.protobuf.ByteString
+          getParamsBytes(int index);
+
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      java.util.List<java.lang.String>
+          getTagsList();
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      int getTagsCount();
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      java.lang.String getTags(int index);
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      com.google.protobuf.ByteString
+          getTagsBytes(int index);
+    }
+    /**
+     * Protobuf type {@code mlflow.ListAllColumns.Response}
+     */
+    public  static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.ListAllColumns.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+        attributes_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        metrics_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        params_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        tags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                  attributes_ = new com.google.protobuf.LazyStringArrayList();
+                  mutable_bitField0_ |= 0x00000001;
+                }
+                attributes_.add(bs);
+                break;
+              }
+              case 18: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                  metrics_ = new com.google.protobuf.LazyStringArrayList();
+                  mutable_bitField0_ |= 0x00000002;
+                }
+                metrics_.add(bs);
+                break;
+              }
+              case 26: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                  params_ = new com.google.protobuf.LazyStringArrayList();
+                  mutable_bitField0_ |= 0x00000004;
+                }
+                params_.add(bs);
+                break;
+              }
+              case 34: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+                  tags_ = new com.google.protobuf.LazyStringArrayList();
+                  mutable_bitField0_ |= 0x00000008;
+                }
+                tags_.add(bs);
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+            attributes_ = attributes_.getUnmodifiableView();
+          }
+          if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+            metrics_ = metrics_.getUnmodifiableView();
+          }
+          if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+            params_ = params_.getUnmodifiableView();
+          }
+          if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+            tags_ = tags_.getUnmodifiableView();
+          }
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.ListAllColumns.Response.class, org.mlflow.api.proto.Service.ListAllColumns.Response.Builder.class);
+      }
+
+      public static final int ATTRIBUTES_FIELD_NUMBER = 1;
+      private com.google.protobuf.LazyStringList attributes_;
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getAttributesList() {
+        return attributes_;
+      }
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      public int getAttributesCount() {
+        return attributes_.size();
+      }
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      public java.lang.String getAttributes(int index) {
+        return attributes_.get(index);
+      }
+      /**
+       * <code>repeated string attributes = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getAttributesBytes(int index) {
+        return attributes_.getByteString(index);
+      }
+
+      public static final int METRICS_FIELD_NUMBER = 2;
+      private com.google.protobuf.LazyStringList metrics_;
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getMetricsList() {
+        return metrics_;
+      }
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      public int getMetricsCount() {
+        return metrics_.size();
+      }
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      public java.lang.String getMetrics(int index) {
+        return metrics_.get(index);
+      }
+      /**
+       * <code>repeated string metrics = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getMetricsBytes(int index) {
+        return metrics_.getByteString(index);
+      }
+
+      public static final int PARAMS_FIELD_NUMBER = 3;
+      private com.google.protobuf.LazyStringList params_;
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getParamsList() {
+        return params_;
+      }
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      public int getParamsCount() {
+        return params_.size();
+      }
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      public java.lang.String getParams(int index) {
+        return params_.get(index);
+      }
+      /**
+       * <code>repeated string params = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getParamsBytes(int index) {
+        return params_.getByteString(index);
+      }
+
+      public static final int TAGS_FIELD_NUMBER = 4;
+      private com.google.protobuf.LazyStringList tags_;
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getTagsList() {
+        return tags_;
+      }
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      public int getTagsCount() {
+        return tags_.size();
+      }
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      public java.lang.String getTags(int index) {
+        return tags_.get(index);
+      }
+      /**
+       * <code>repeated string tags = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getTagsBytes(int index) {
+        return tags_.getByteString(index);
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        for (int i = 0; i < attributes_.size(); i++) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 1, attributes_.getRaw(i));
+        }
+        for (int i = 0; i < metrics_.size(); i++) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 2, metrics_.getRaw(i));
+        }
+        for (int i = 0; i < params_.size(); i++) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 3, params_.getRaw(i));
+        }
+        for (int i = 0; i < tags_.size(); i++) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 4, tags_.getRaw(i));
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        {
+          int dataSize = 0;
+          for (int i = 0; i < attributes_.size(); i++) {
+            dataSize += computeStringSizeNoTag(attributes_.getRaw(i));
+          }
+          size += dataSize;
+          size += 1 * getAttributesList().size();
+        }
+        {
+          int dataSize = 0;
+          for (int i = 0; i < metrics_.size(); i++) {
+            dataSize += computeStringSizeNoTag(metrics_.getRaw(i));
+          }
+          size += dataSize;
+          size += 1 * getMetricsList().size();
+        }
+        {
+          int dataSize = 0;
+          for (int i = 0; i < params_.size(); i++) {
+            dataSize += computeStringSizeNoTag(params_.getRaw(i));
+          }
+          size += dataSize;
+          size += 1 * getParamsList().size();
+        }
+        {
+          int dataSize = 0;
+          for (int i = 0; i < tags_.size(); i++) {
+            dataSize += computeStringSizeNoTag(tags_.getRaw(i));
+          }
+          size += dataSize;
+          size += 1 * getTagsList().size();
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.Service.ListAllColumns.Response)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.Service.ListAllColumns.Response other = (org.mlflow.api.proto.Service.ListAllColumns.Response) obj;
+
+        boolean result = true;
+        result = result && getAttributesList()
+            .equals(other.getAttributesList());
+        result = result && getMetricsList()
+            .equals(other.getMetricsList());
+        result = result && getParamsList()
+            .equals(other.getParamsList());
+        result = result && getTagsList()
+            .equals(other.getTagsList());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (getAttributesCount() > 0) {
+          hash = (37 * hash) + ATTRIBUTES_FIELD_NUMBER;
+          hash = (53 * hash) + getAttributesList().hashCode();
+        }
+        if (getMetricsCount() > 0) {
+          hash = (37 * hash) + METRICS_FIELD_NUMBER;
+          hash = (53 * hash) + getMetricsList().hashCode();
+        }
+        if (getParamsCount() > 0) {
+          hash = (37 * hash) + PARAMS_FIELD_NUMBER;
+          hash = (53 * hash) + getParamsList().hashCode();
+        }
+        if (getTagsCount() > 0) {
+          hash = (37 * hash) + TAGS_FIELD_NUMBER;
+          hash = (53 * hash) + getTagsList().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.Service.ListAllColumns.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.ListAllColumns.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.ListAllColumns.Response)
+          org.mlflow.api.proto.Service.ListAllColumns.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.Service.ListAllColumns.Response.class, org.mlflow.api.proto.Service.ListAllColumns.Response.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.Service.ListAllColumns.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          attributes_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000001);
+          metrics_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000002);
+          params_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000004);
+          tags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000008);
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.ListAllColumns.Response getDefaultInstanceForType() {
+          return org.mlflow.api.proto.Service.ListAllColumns.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.ListAllColumns.Response build() {
+          org.mlflow.api.proto.Service.ListAllColumns.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.ListAllColumns.Response buildPartial() {
+          org.mlflow.api.proto.Service.ListAllColumns.Response result = new org.mlflow.api.proto.Service.ListAllColumns.Response(this);
+          int from_bitField0_ = bitField0_;
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            attributes_ = attributes_.getUnmodifiableView();
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.attributes_ = attributes_;
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            metrics_ = metrics_.getUnmodifiableView();
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.metrics_ = metrics_;
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            params_ = params_.getUnmodifiableView();
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.params_ = params_;
+          if (((bitField0_ & 0x00000008) == 0x00000008)) {
+            tags_ = tags_.getUnmodifiableView();
+            bitField0_ = (bitField0_ & ~0x00000008);
+          }
+          result.tags_ = tags_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.Service.ListAllColumns.Response) {
+            return mergeFrom((org.mlflow.api.proto.Service.ListAllColumns.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.Service.ListAllColumns.Response other) {
+          if (other == org.mlflow.api.proto.Service.ListAllColumns.Response.getDefaultInstance()) return this;
+          if (!other.attributes_.isEmpty()) {
+            if (attributes_.isEmpty()) {
+              attributes_ = other.attributes_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureAttributesIsMutable();
+              attributes_.addAll(other.attributes_);
+            }
+            onChanged();
+          }
+          if (!other.metrics_.isEmpty()) {
+            if (metrics_.isEmpty()) {
+              metrics_ = other.metrics_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureMetricsIsMutable();
+              metrics_.addAll(other.metrics_);
+            }
+            onChanged();
+          }
+          if (!other.params_.isEmpty()) {
+            if (params_.isEmpty()) {
+              params_ = other.params_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensureParamsIsMutable();
+              params_.addAll(other.params_);
+            }
+            onChanged();
+          }
+          if (!other.tags_.isEmpty()) {
+            if (tags_.isEmpty()) {
+              tags_ = other.tags_;
+              bitField0_ = (bitField0_ & ~0x00000008);
+            } else {
+              ensureTagsIsMutable();
+              tags_.addAll(other.tags_);
+            }
+            onChanged();
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.Service.ListAllColumns.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.Service.ListAllColumns.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private com.google.protobuf.LazyStringList attributes_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        private void ensureAttributesIsMutable() {
+          if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+            attributes_ = new com.google.protobuf.LazyStringArrayList(attributes_);
+            bitField0_ |= 0x00000001;
+           }
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public com.google.protobuf.ProtocolStringList
+            getAttributesList() {
+          return attributes_.getUnmodifiableView();
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public int getAttributesCount() {
+          return attributes_.size();
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public java.lang.String getAttributes(int index) {
+          return attributes_.get(index);
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public com.google.protobuf.ByteString
+            getAttributesBytes(int index) {
+          return attributes_.getByteString(index);
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public Builder setAttributes(
+            int index, java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAttributesIsMutable();
+          attributes_.set(index, value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public Builder addAttributes(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAttributesIsMutable();
+          attributes_.add(value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public Builder addAllAttributes(
+            java.lang.Iterable<java.lang.String> values) {
+          ensureAttributesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, attributes_);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public Builder clearAttributes() {
+          attributes_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string attributes = 1;</code>
+         */
+        public Builder addAttributesBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAttributesIsMutable();
+          attributes_.add(value);
+          onChanged();
+          return this;
+        }
+
+        private com.google.protobuf.LazyStringList metrics_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        private void ensureMetricsIsMutable() {
+          if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+            metrics_ = new com.google.protobuf.LazyStringArrayList(metrics_);
+            bitField0_ |= 0x00000002;
+           }
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public com.google.protobuf.ProtocolStringList
+            getMetricsList() {
+          return metrics_.getUnmodifiableView();
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public int getMetricsCount() {
+          return metrics_.size();
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public java.lang.String getMetrics(int index) {
+          return metrics_.get(index);
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public com.google.protobuf.ByteString
+            getMetricsBytes(int index) {
+          return metrics_.getByteString(index);
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public Builder setMetrics(
+            int index, java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureMetricsIsMutable();
+          metrics_.set(index, value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public Builder addMetrics(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureMetricsIsMutable();
+          metrics_.add(value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public Builder addAllMetrics(
+            java.lang.Iterable<java.lang.String> values) {
+          ensureMetricsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, metrics_);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public Builder clearMetrics() {
+          metrics_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string metrics = 2;</code>
+         */
+        public Builder addMetricsBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureMetricsIsMutable();
+          metrics_.add(value);
+          onChanged();
+          return this;
+        }
+
+        private com.google.protobuf.LazyStringList params_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        private void ensureParamsIsMutable() {
+          if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+            params_ = new com.google.protobuf.LazyStringArrayList(params_);
+            bitField0_ |= 0x00000004;
+           }
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public com.google.protobuf.ProtocolStringList
+            getParamsList() {
+          return params_.getUnmodifiableView();
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public int getParamsCount() {
+          return params_.size();
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public java.lang.String getParams(int index) {
+          return params_.get(index);
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public com.google.protobuf.ByteString
+            getParamsBytes(int index) {
+          return params_.getByteString(index);
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public Builder setParams(
+            int index, java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureParamsIsMutable();
+          params_.set(index, value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public Builder addParams(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureParamsIsMutable();
+          params_.add(value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public Builder addAllParams(
+            java.lang.Iterable<java.lang.String> values) {
+          ensureParamsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, params_);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public Builder clearParams() {
+          params_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string params = 3;</code>
+         */
+        public Builder addParamsBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureParamsIsMutable();
+          params_.add(value);
+          onChanged();
+          return this;
+        }
+
+        private com.google.protobuf.LazyStringList tags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        private void ensureTagsIsMutable() {
+          if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+            tags_ = new com.google.protobuf.LazyStringArrayList(tags_);
+            bitField0_ |= 0x00000008;
+           }
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public com.google.protobuf.ProtocolStringList
+            getTagsList() {
+          return tags_.getUnmodifiableView();
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public int getTagsCount() {
+          return tags_.size();
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public java.lang.String getTags(int index) {
+          return tags_.get(index);
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public com.google.protobuf.ByteString
+            getTagsBytes(int index) {
+          return tags_.getByteString(index);
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public Builder setTags(
+            int index, java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTagsIsMutable();
+          tags_.set(index, value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public Builder addTags(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTagsIsMutable();
+          tags_.add(value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public Builder addAllTags(
+            java.lang.Iterable<java.lang.String> values) {
+          ensureTagsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, tags_);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public Builder clearTags() {
+          tags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000008);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string tags = 4;</code>
+         */
+        public Builder addTagsBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureTagsIsMutable();
+          tags_.add(value);
+          onChanged();
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.ListAllColumns.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.ListAllColumns.Response)
+      private static final org.mlflow.api.proto.Service.ListAllColumns.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.ListAllColumns.Response();
+      }
+
+      public static org.mlflow.api.proto.Service.ListAllColumns.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.ListAllColumns.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    public static final int EXPERIMENT_IDS_FIELD_NUMBER = 1;
+    private com.google.protobuf.LazyStringList experimentIds_;
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getExperimentIdsList() {
+      return experimentIds_;
+    }
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    public int getExperimentIdsCount() {
+      return experimentIds_.size();
+    }
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    public java.lang.String getExperimentIds(int index) {
+      return experimentIds_.get(index);
+    }
+    /**
+     * <pre>
+     * List of experiment IDs to search over.
+     * </pre>
+     *
+     * <code>repeated string experiment_ids = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getExperimentIdsBytes(int index) {
+      return experimentIds_.getByteString(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < experimentIds_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, experimentIds_.getRaw(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < experimentIds_.size(); i++) {
+          dataSize += computeStringSizeNoTag(experimentIds_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getExperimentIdsList().size();
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.Service.ListAllColumns)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.Service.ListAllColumns other = (org.mlflow.api.proto.Service.ListAllColumns) obj;
+
+      boolean result = true;
+      result = result && getExperimentIdsList()
+          .equals(other.getExperimentIdsList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getExperimentIdsCount() > 0) {
+        hash = (37 * hash) + EXPERIMENT_IDS_FIELD_NUMBER;
+        hash = (53 * hash) + getExperimentIdsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.ListAllColumns parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.Service.ListAllColumns prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.ListAllColumns}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.ListAllColumns)
+        org.mlflow.api.proto.Service.ListAllColumnsOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.ListAllColumns.class, org.mlflow.api.proto.Service.ListAllColumns.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.Service.ListAllColumns.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        experimentIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_ListAllColumns_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.ListAllColumns getDefaultInstanceForType() {
+        return org.mlflow.api.proto.Service.ListAllColumns.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.ListAllColumns build() {
+        org.mlflow.api.proto.Service.ListAllColumns result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.ListAllColumns buildPartial() {
+        org.mlflow.api.proto.Service.ListAllColumns result = new org.mlflow.api.proto.Service.ListAllColumns(this);
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          experimentIds_ = experimentIds_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.experimentIds_ = experimentIds_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.Service.ListAllColumns) {
+          return mergeFrom((org.mlflow.api.proto.Service.ListAllColumns)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.Service.ListAllColumns other) {
+        if (other == org.mlflow.api.proto.Service.ListAllColumns.getDefaultInstance()) return this;
+        if (!other.experimentIds_.isEmpty()) {
+          if (experimentIds_.isEmpty()) {
+            experimentIds_ = other.experimentIds_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureExperimentIdsIsMutable();
+            experimentIds_.addAll(other.experimentIds_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.Service.ListAllColumns parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.Service.ListAllColumns) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.google.protobuf.LazyStringList experimentIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureExperimentIdsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          experimentIds_ = new com.google.protobuf.LazyStringArrayList(experimentIds_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getExperimentIdsList() {
+        return experimentIds_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public int getExperimentIdsCount() {
+        return experimentIds_.size();
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public java.lang.String getExperimentIds(int index) {
+        return experimentIds_.get(index);
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getExperimentIdsBytes(int index) {
+        return experimentIds_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public Builder setExperimentIds(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureExperimentIdsIsMutable();
+        experimentIds_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public Builder addExperimentIds(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureExperimentIdsIsMutable();
+        experimentIds_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public Builder addAllExperimentIds(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureExperimentIdsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, experimentIds_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public Builder clearExperimentIds() {
+        experimentIds_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * List of experiment IDs to search over.
+       * </pre>
+       *
+       * <code>repeated string experiment_ids = 1;</code>
+       */
+      public Builder addExperimentIdsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureExperimentIdsIsMutable();
+        experimentIds_.add(value);
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.ListAllColumns)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.ListAllColumns)
+    private static final org.mlflow.api.proto.Service.ListAllColumns DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.ListAllColumns();
+    }
+
+    public static org.mlflow.api.proto.Service.ListAllColumns getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<ListAllColumns>
+        PARSER = new com.google.protobuf.AbstractParser<ListAllColumns>() {
+      @java.lang.Override
+      public ListAllColumns parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ListAllColumns(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ListAllColumns> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ListAllColumns> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.Service.ListAllColumns getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface SearchRunsOrBuilder extends
       // @@protoc_insertion_point(interface_extends:mlflow.SearchRuns)
       com.google.protobuf.MessageOrBuilder {
@@ -49128,6 +50966,16 @@ public final class Service {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_GetRun_Response_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_ListAllColumns_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_ListAllColumns_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_ListAllColumns_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_ListAllColumns_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_SearchRuns_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -49282,149 +51130,159 @@ public final class Service {
       "rpc.RPC[$this.Response]\"}\n\006GetRun\022\016\n\006run" +
       "_id\030\002 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\032$\n\010Response\022" +
       "\030\n\003run\030\001 \001(\0132\013.mlflow.Run:+\342?(\n&com.data" +
-      "bricks.rpc.RPC[$this.Response]\"\365\003\n\nSearc" +
-      "hRuns\022\026\n\016experiment_ids\030\001 \003(\t\022\016\n\006filter\030" +
-      "\004 \001(\t\0224\n\rrun_view_type\030\003 \001(\0162\020.mlflow.Vi" +
-      "ewType:\013ACTIVE_ONLY\022\031\n\013max_results\030\005 \001(\005" +
-      ":\0041000\022\020\n\010order_by\030\006 \003(\t\022\022\n\npage_token\030\007" +
-      " \001(\t\0227\n\021metrics_whitelist\030\010 \001(\0132\034.mlflow" +
-      ".SearchRuns.WhiteList\0226\n\020params_whitelis" +
-      "t\030\t \001(\0132\034.mlflow.SearchRuns.WhiteList\0224\n" +
-      "\016tags_whitelist\030\n \001(\0132\034.mlflow.SearchRun" +
-      "s.WhiteList\032W\n\010Response\022\031\n\004runs\030\001 \003(\0132\013." +
-      "mlflow.Run\022\027\n\017next_page_token\030\002 \001(\t\022\027\n\017t" +
-      "otal_run_count\030\003 \001(\005\032\033\n\tWhiteList\022\016\n\006fie" +
-      "lds\030\001 \003(\t:+\342?(\n&com.databricks.rpc.RPC[$" +
-      "this.Response]\"\253\001\n\rListArtifacts\022\016\n\006run_" +
-      "id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\014\n\004path\030\002 \001(\t" +
-      "\032=\n\010Response\022\020\n\010root_uri\030\001 \001(\t\022\037\n\005files\030" +
-      "\002 \003(\0132\020.mlflow.FileInfo:+\342?(\n&com.databr" +
-      "icks.rpc.RPC[$this.Response]\";\n\010FileInfo" +
-      "\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir\030\002 \001(\010\022\021\n\tfile_s" +
-      "ize\030\003 \001(\003\"\250\001\n\020GetMetricHistory\022\016\n\006run_id" +
-      "\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\030\n\nmetric_key\030\002" +
-      " \001(\tB\004\370\206\031\001\032+\n\010Response\022\037\n\007metrics\030\001 \003(\0132" +
-      "\016.mlflow.Metric:+\342?(\n&com.databricks.rpc" +
-      ".RPC[$this.Response]\"\261\001\n\010LogBatch\022\016\n\006run" +
-      "_id\030\001 \001(\t\022\037\n\007metrics\030\002 \003(\0132\016.mlflow.Metr" +
-      "ic\022\035\n\006params\030\003 \003(\0132\r.mlflow.Param\022\034\n\004tag" +
-      "s\030\004 \003(\0132\016.mlflow.RunTag\032\n\n\010Response:+\342?(" +
-      "\n&com.databricks.rpc.RPC[$this.Response]" +
-      "\"\225\001\n\023GetExperimentByName\022\035\n\017experiment_n" +
-      "ame\030\001 \001(\tB\004\370\206\031\001\0322\n\010Response\022&\n\nexperimen" +
-      "t\030\001 \001(\0132\022.mlflow.Experiment:+\342?(\n&com.da" +
-      "tabricks.rpc.RPC[$this.Response]\"\216\001\n\027Upd" +
-      "ateArtifactsLocation\022\024\n\006run_id\030\001 \001(\tB\004\370\206" +
-      "\031\001\022$\n\026new_artifacts_location\030\002 \001(\tB\004\370\206\031\001" +
-      "\032\n\n\010Response:+\342?(\n&com.databricks.rpc.RP" +
-      "C[$this.Response]*6\n\010ViewType\022\017\n\013ACTIVE_" +
-      "ONLY\020\001\022\020\n\014DELETED_ONLY\020\002\022\007\n\003ALL\020\003*I\n\nSou" +
-      "rceType\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n\007PROJEC" +
-      "T\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tRunStatu" +
-      "s\022\013\n\007RUNNING\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010FINISHE" +
-      "D\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\276\037\n\rMlflowSe" +
-      "rvice\022\246\001\n\023getExperimentByName\022\033.mlflow.G" +
-      "etExperimentByName\032$.mlflow.GetExperimen" +
-      "tByName.Response\"L\362\206\031H\n,\n\003GET\022\037/mlflow/e" +
-      "xperiments/get-by-name\032\004\010\002\020\000\020\001*\026Get Expe" +
-      "riment By Name\022\306\001\n\020createExperiment\022\030.ml" +
-      "flow.CreateExperiment\032!.mlflow.CreateExp" +
-      "eriment.Response\"u\362\206\031q\n(\n\004POST\022\032/mlflow/" +
-      "experiments/create\032\004\010\002\020\000\n0\n\004POST\022\"/previ" +
-      "ew/mlflow/experiments/create\032\004\010\002\020\000\020\001*\021Cr" +
-      "eate Experiment\022\274\001\n\017listExperiments\022\027.ml" +
-      "flow.ListExperiments\032 .mlflow.ListExperi" +
-      "ments.Response\"n\362\206\031j\n%\n\003GET\022\030/mlflow/exp" +
-      "eriments/list\032\004\010\002\020\000\n-\n\003GET\022 /preview/mlf" +
-      "low/experiments/list\032\004\010\002\020\000\020\001*\020List Exper" +
-      "iments\022\262\001\n\rgetExperiment\022\025.mlflow.GetExp" +
-      "eriment\032\036.mlflow.GetExperiment.Response\"" +
-      "j\362\206\031f\n$\n\003GET\022\027/mlflow/experiments/get\032\004\010" +
-      "\002\020\000\n,\n\003GET\022\037/preview/mlflow/experiments/" +
-      "get\032\004\010\002\020\000\020\001*\016Get Experiment\022\306\001\n\020deleteEx" +
-      "periment\022\030.mlflow.DeleteExperiment\032!.mlf" +
-      "low.DeleteExperiment.Response\"u\362\206\031q\n(\n\004P" +
-      "OST\022\032/mlflow/experiments/delete\032\004\010\002\020\000\n0\n" +
-      "\004POST\022\"/preview/mlflow/experiments/delet" +
-      "e\032\004\010\002\020\000\020\001*\021Delete Experiment\022\314\001\n\021restore" +
-      "Experiment\022\031.mlflow.RestoreExperiment\032\"." +
-      "mlflow.RestoreExperiment.Response\"x\362\206\031t\n" +
-      ")\n\004POST\022\033/mlflow/experiments/restore\032\004\010\002" +
-      "\020\000\n1\n\004POST\022#/preview/mlflow/experiments/" +
-      "restore\032\004\010\002\020\000\020\001*\022Restore Experiment\022\306\001\n\020" +
-      "updateExperiment\022\030.mlflow.UpdateExperime" +
-      "nt\032!.mlflow.UpdateExperiment.Response\"u\362" +
-      "\206\031q\n(\n\004POST\022\032/mlflow/experiments/update\032" +
-      "\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/experimen" +
-      "ts/update\032\004\010\002\020\000\020\001*\021Update Experiment\022\234\001\n" +
-      "\tcreateRun\022\021.mlflow.CreateRun\032\032.mlflow.C" +
-      "reateRun.Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow" +
-      "/runs/create\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlf" +
-      "low/runs/create\032\004\010\002\020\000\020\001*\nCreate Run\022\234\001\n\t" +
-      "updateRun\022\021.mlflow.UpdateRun\032\032.mlflow.Up" +
-      "dateRun.Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/" +
-      "runs/update\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlfl" +
-      "ow/runs/update\032\004\010\002\020\000\020\001*\nUpdate Run\022\234\001\n\td" +
-      "eleteRun\022\021.mlflow.DeleteRun\032\032.mlflow.Del" +
-      "eteRun.Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/r" +
-      "uns/delete\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflo" +
-      "w/runs/delete\032\004\010\002\020\000\020\001*\nDelete Run\022\242\001\n\nre" +
-      "storeRun\022\022.mlflow.RestoreRun\032\033.mlflow.Re" +
-      "storeRun.Response\"c\362\206\031_\n\"\n\004POST\022\024/mlflow" +
-      "/runs/restore\032\004\010\002\020\000\n*\n\004POST\022\034/preview/ml" +
-      "flow/runs/restore\032\004\010\002\020\000\020\001*\013Restore Run\022\244" +
-      "\001\n\tlogMetric\022\021.mlflow.LogMetric\032\032.mlflow" +
-      ".LogMetric.Response\"h\362\206\031d\n%\n\004POST\022\027/mlfl" +
-      "ow/runs/log-metric\032\004\010\002\020\000\n-\n\004POST\022\037/previ" +
-      "ew/mlflow/runs/log-metric\032\004\010\002\020\000\020\001*\nLog M" +
-      "etric\022\246\001\n\010logParam\022\020.mlflow.LogParam\032\031.m" +
-      "lflow.LogParam.Response\"m\362\206\031i\n(\n\004POST\022\032/" +
-      "mlflow/runs/log-parameter\032\004\010\002\020\000\n0\n\004POST\022" +
-      "\"/preview/mlflow/runs/log-parameter\032\004\010\002\020" +
-      "\000\020\001*\tLog Param\022\341\001\n\020setExperimentTag\022\030.ml" +
-      "flow.SetExperimentTag\032!.mlflow.SetExperi" +
-      "mentTag.Response\"\217\001\362\206\031\212\001\n4\n\004POST\022&/mlflo" +
-      "w/experiments/set-experiment-tag\032\004\010\002\020\000\n<" +
-      "\n\004POST\022./preview/mlflow/experiments/set-" +
-      "experiment-tag\032\004\010\002\020\000\020\001*\022Set Experiment T" +
-      "ag\022\222\001\n\006setTag\022\016.mlflow.SetTag\032\027.mlflow.S" +
-      "etTag.Response\"_\362\206\031[\n\"\n\004POST\022\024/mlflow/ru" +
-      "ns/set-tag\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflo" +
-      "w/runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022\244\001\n\tdele" +
-      "teTag\022\021.mlflow.DeleteTag\032\032.mlflow.Delete" +
-      "Tag.Response\"h\362\206\031d\n%\n\004POST\022\027/mlflow/runs" +
-      "/delete-tag\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlfl" +
-      "ow/runs/delete-tag\032\004\010\002\020\000\020\001*\nDelete Tag\022\210" +
-      "\001\n\006getRun\022\016.mlflow.GetRun\032\027.mlflow.GetRu" +
-      "n.Response\"U\362\206\031Q\n\035\n\003GET\022\020/mlflow/runs/ge" +
-      "t\032\004\010\002\020\000\n%\n\003GET\022\030/preview/mlflow/runs/get" +
-      "\032\004\010\002\020\000\020\001*\007Get Run\022\314\001\n\nsearchRuns\022\022.mlflo" +
-      "w.SearchRuns\032\033.mlflow.SearchRuns.Respons" +
-      "e\"\214\001\362\206\031\207\001\n!\n\004POST\022\023/mlflow/runs/search\032\004" +
-      "\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/searc" +
-      "h\032\004\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/runs/sea" +
-      "rch\032\004\010\002\020\000\020\001*\013Search Runs\022\260\001\n\rlistArtifac" +
-      "ts\022\025.mlflow.ListArtifacts\032\036.mlflow.ListA" +
-      "rtifacts.Response\"h\362\206\031d\n#\n\003GET\022\026/mlflow/" +
-      "artifacts/list\032\004\010\002\020\000\n+\n\003GET\022\036/preview/ml" +
-      "flow/artifacts/list\032\004\010\002\020\000\020\001*\016List Artifa" +
-      "cts\022\307\001\n\020getMetricHistory\022\030.mlflow.GetMet" +
-      "ricHistory\032!.mlflow.GetMetricHistory.Res" +
-      "ponse\"v\362\206\031r\n(\n\003GET\022\033/mlflow/metrics/get-" +
-      "history\032\004\010\002\020\000\n0\n\003GET\022#/preview/mlflow/me" +
-      "trics/get-history\032\004\010\002\020\000\020\001*\022Get Metric Hi" +
-      "story\022\373\001\n\027updateArtifactsLocation\022\037.mlfl" +
-      "ow.UpdateArtifactsLocation\032(.mlflow.Upda" +
-      "teArtifactsLocation.Response\"\224\001\362\206\031\217\001\n3\n\003" +
-      "PUT\022&/mlflow/runs/update-artifacts-locat" +
-      "ion\032\004\010\002\020\000\n;\n\003PUT\022./preview/mlflow/runs/u" +
-      "pdate-artifacts-location\032\004\010\002\020\000\020\001*\031Update" +
-      " Artifacts Location\022\236\001\n\010logBatch\022\020.mlflo" +
-      "w.LogBatch\032\031.mlflow.LogBatch.Response\"e\362" +
-      "\206\031a\n$\n\004POST\022\026/mlflow/runs/log-batch\032\004\010\002\020" +
-      "\000\n,\n\004POST\022\036/preview/mlflow/runs/log-batc" +
-      "h\032\004\010\002\020\000\020\001*\tLog BatchB\036\n\024org.mlflow.api.p" +
-      "roto\220\001\001\342?\002\020\001"
+      "bricks.rpc.RPC[$this.Response]\"\244\001\n\016ListA" +
+      "llColumns\022\026\n\016experiment_ids\030\001 \003(\t\032M\n\010Res" +
+      "ponse\022\022\n\nattributes\030\001 \003(\t\022\017\n\007metrics\030\002 \003" +
+      "(\t\022\016\n\006params\030\003 \003(\t\022\014\n\004tags\030\004 \003(\t:+\342?(\n&c" +
+      "om.databricks.rpc.RPC[$this.Response]\"\365\003" +
+      "\n\nSearchRuns\022\026\n\016experiment_ids\030\001 \003(\t\022\016\n\006" +
+      "filter\030\004 \001(\t\0224\n\rrun_view_type\030\003 \001(\0162\020.ml" +
+      "flow.ViewType:\013ACTIVE_ONLY\022\031\n\013max_result" +
+      "s\030\005 \001(\005:\0041000\022\020\n\010order_by\030\006 \003(\t\022\022\n\npage_" +
+      "token\030\007 \001(\t\0227\n\021metrics_whitelist\030\010 \001(\0132\034" +
+      ".mlflow.SearchRuns.WhiteList\0226\n\020params_w" +
+      "hitelist\030\t \001(\0132\034.mlflow.SearchRuns.White" +
+      "List\0224\n\016tags_whitelist\030\n \001(\0132\034.mlflow.Se" +
+      "archRuns.WhiteList\032W\n\010Response\022\031\n\004runs\030\001" +
+      " \003(\0132\013.mlflow.Run\022\027\n\017next_page_token\030\002 \001" +
+      "(\t\022\027\n\017total_run_count\030\003 \001(\005\032\033\n\tWhiteList" +
+      "\022\016\n\006fields\030\001 \003(\t:+\342?(\n&com.databricks.rp" +
+      "c.RPC[$this.Response]\"\253\001\n\rListArtifacts\022" +
+      "\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\014\n\004pat" +
+      "h\030\002 \001(\t\032=\n\010Response\022\020\n\010root_uri\030\001 \001(\t\022\037\n" +
+      "\005files\030\002 \003(\0132\020.mlflow.FileInfo:+\342?(\n&com" +
+      ".databricks.rpc.RPC[$this.Response]\";\n\010F" +
+      "ileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir\030\002 \001(\010\022\021\n" +
+      "\tfile_size\030\003 \001(\003\"\250\001\n\020GetMetricHistory\022\016\n" +
+      "\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\030\n\nmetri" +
+      "c_key\030\002 \001(\tB\004\370\206\031\001\032+\n\010Response\022\037\n\007metrics" +
+      "\030\001 \003(\0132\016.mlflow.Metric:+\342?(\n&com.databri" +
+      "cks.rpc.RPC[$this.Response]\"\261\001\n\010LogBatch" +
+      "\022\016\n\006run_id\030\001 \001(\t\022\037\n\007metrics\030\002 \003(\0132\016.mlfl" +
+      "ow.Metric\022\035\n\006params\030\003 \003(\0132\r.mlflow.Param" +
+      "\022\034\n\004tags\030\004 \003(\0132\016.mlflow.RunTag\032\n\n\010Respon" +
+      "se:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
+      "sponse]\"\225\001\n\023GetExperimentByName\022\035\n\017exper" +
+      "iment_name\030\001 \001(\tB\004\370\206\031\001\0322\n\010Response\022&\n\nex" +
+      "periment\030\001 \001(\0132\022.mlflow.Experiment:+\342?(\n" +
+      "&com.databricks.rpc.RPC[$this.Response]\"" +
+      "\216\001\n\027UpdateArtifactsLocation\022\024\n\006run_id\030\001 " +
+      "\001(\tB\004\370\206\031\001\022$\n\026new_artifacts_location\030\002 \001(" +
+      "\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks" +
+      ".rpc.RPC[$this.Response]*6\n\010ViewType\022\017\n\013" +
+      "ACTIVE_ONLY\020\001\022\020\n\014DELETED_ONLY\020\002\022\007\n\003ALL\020\003" +
+      "*I\n\nSourceType\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n" +
+      "\007PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tR" +
+      "unStatus\022\013\n\007RUNNING\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010" +
+      "FINISHED\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\241!\n\rM" +
+      "lflowService\022\246\001\n\023getExperimentByName\022\033.m" +
+      "lflow.GetExperimentByName\032$.mlflow.GetEx" +
+      "perimentByName.Response\"L\362\206\031H\n,\n\003GET\022\037/m" +
+      "lflow/experiments/get-by-name\032\004\010\002\020\000\020\001*\026G" +
+      "et Experiment By Name\022\306\001\n\020createExperime" +
+      "nt\022\030.mlflow.CreateExperiment\032!.mlflow.Cr" +
+      "eateExperiment.Response\"u\362\206\031q\n(\n\004POST\022\032/" +
+      "mlflow/experiments/create\032\004\010\002\020\000\n0\n\004POST\022" +
+      "\"/preview/mlflow/experiments/create\032\004\010\002\020" +
+      "\000\020\001*\021Create Experiment\022\274\001\n\017listExperimen" +
+      "ts\022\027.mlflow.ListExperiments\032 .mlflow.Lis" +
+      "tExperiments.Response\"n\362\206\031j\n%\n\003GET\022\030/mlf" +
+      "low/experiments/list\032\004\010\002\020\000\n-\n\003GET\022 /prev" +
+      "iew/mlflow/experiments/list\032\004\010\002\020\000\020\001*\020Lis" +
+      "t Experiments\022\262\001\n\rgetExperiment\022\025.mlflow" +
+      ".GetExperiment\032\036.mlflow.GetExperiment.Re" +
+      "sponse\"j\362\206\031f\n$\n\003GET\022\027/mlflow/experiments" +
+      "/get\032\004\010\002\020\000\n,\n\003GET\022\037/preview/mlflow/exper" +
+      "iments/get\032\004\010\002\020\000\020\001*\016Get Experiment\022\306\001\n\020d" +
+      "eleteExperiment\022\030.mlflow.DeleteExperimen" +
+      "t\032!.mlflow.DeleteExperiment.Response\"u\362\206" +
+      "\031q\n(\n\004POST\022\032/mlflow/experiments/delete\032\004" +
+      "\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/experiment" +
+      "s/delete\032\004\010\002\020\000\020\001*\021Delete Experiment\022\314\001\n\021" +
+      "restoreExperiment\022\031.mlflow.RestoreExperi" +
+      "ment\032\".mlflow.RestoreExperiment.Response" +
+      "\"x\362\206\031t\n)\n\004POST\022\033/mlflow/experiments/rest" +
+      "ore\032\004\010\002\020\000\n1\n\004POST\022#/preview/mlflow/exper" +
+      "iments/restore\032\004\010\002\020\000\020\001*\022Restore Experime" +
+      "nt\022\306\001\n\020updateExperiment\022\030.mlflow.UpdateE" +
+      "xperiment\032!.mlflow.UpdateExperiment.Resp" +
+      "onse\"u\362\206\031q\n(\n\004POST\022\032/mlflow/experiments/" +
+      "update\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/ex" +
+      "periments/update\032\004\010\002\020\000\020\001*\021Update Experim" +
+      "ent\022\234\001\n\tcreateRun\022\021.mlflow.CreateRun\032\032.m" +
+      "lflow.CreateRun.Response\"`\362\206\031\\\n!\n\004POST\022\023" +
+      "/mlflow/runs/create\032\004\010\002\020\000\n)\n\004POST\022\033/prev" +
+      "iew/mlflow/runs/create\032\004\010\002\020\000\020\001*\nCreate R" +
+      "un\022\234\001\n\tupdateRun\022\021.mlflow.UpdateRun\032\032.ml" +
+      "flow.UpdateRun.Response\"`\362\206\031\\\n!\n\004POST\022\023/" +
+      "mlflow/runs/update\032\004\010\002\020\000\n)\n\004POST\022\033/previ" +
+      "ew/mlflow/runs/update\032\004\010\002\020\000\020\001*\nUpdate Ru" +
+      "n\022\234\001\n\tdeleteRun\022\021.mlflow.DeleteRun\032\032.mlf" +
+      "low.DeleteRun.Response\"`\362\206\031\\\n!\n\004POST\022\023/m" +
+      "lflow/runs/delete\032\004\010\002\020\000\n)\n\004POST\022\033/previe" +
+      "w/mlflow/runs/delete\032\004\010\002\020\000\020\001*\nDelete Run" +
+      "\022\242\001\n\nrestoreRun\022\022.mlflow.RestoreRun\032\033.ml" +
+      "flow.RestoreRun.Response\"c\362\206\031_\n\"\n\004POST\022\024" +
+      "/mlflow/runs/restore\032\004\010\002\020\000\n*\n\004POST\022\034/pre" +
+      "view/mlflow/runs/restore\032\004\010\002\020\000\020\001*\013Restor" +
+      "e Run\022\244\001\n\tlogMetric\022\021.mlflow.LogMetric\032\032" +
+      ".mlflow.LogMetric.Response\"h\362\206\031d\n%\n\004POST" +
+      "\022\027/mlflow/runs/log-metric\032\004\010\002\020\000\n-\n\004POST\022" +
+      "\037/preview/mlflow/runs/log-metric\032\004\010\002\020\000\020\001" +
+      "*\nLog Metric\022\246\001\n\010logParam\022\020.mlflow.LogPa" +
+      "ram\032\031.mlflow.LogParam.Response\"m\362\206\031i\n(\n\004" +
+      "POST\022\032/mlflow/runs/log-parameter\032\004\010\002\020\000\n0" +
+      "\n\004POST\022\"/preview/mlflow/runs/log-paramet" +
+      "er\032\004\010\002\020\000\020\001*\tLog Param\022\341\001\n\020setExperimentT" +
+      "ag\022\030.mlflow.SetExperimentTag\032!.mlflow.Se" +
+      "tExperimentTag.Response\"\217\001\362\206\031\212\001\n4\n\004POST\022" +
+      "&/mlflow/experiments/set-experiment-tag\032" +
+      "\004\010\002\020\000\n<\n\004POST\022./preview/mlflow/experimen" +
+      "ts/set-experiment-tag\032\004\010\002\020\000\020\001*\022Set Exper" +
+      "iment Tag\022\222\001\n\006setTag\022\016.mlflow.SetTag\032\027.m" +
+      "lflow.SetTag.Response\"_\362\206\031[\n\"\n\004POST\022\024/ml" +
+      "flow/runs/set-tag\032\004\010\002\020\000\n*\n\004POST\022\034/previe" +
+      "w/mlflow/runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022\244" +
+      "\001\n\tdeleteTag\022\021.mlflow.DeleteTag\032\032.mlflow" +
+      ".DeleteTag.Response\"h\362\206\031d\n%\n\004POST\022\027/mlfl" +
+      "ow/runs/delete-tag\032\004\010\002\020\000\n-\n\004POST\022\037/previ" +
+      "ew/mlflow/runs/delete-tag\032\004\010\002\020\000\020\001*\nDelet" +
+      "e Tag\022\210\001\n\006getRun\022\016.mlflow.GetRun\032\027.mlflo" +
+      "w.GetRun.Response\"U\362\206\031Q\n\035\n\003GET\022\020/mlflow/" +
+      "runs/get\032\004\010\002\020\000\n%\n\003GET\022\030/preview/mlflow/r" +
+      "uns/get\032\004\010\002\020\000\020\001*\007Get Run\022\340\001\n\016listAllColu" +
+      "mns\022\026.mlflow.ListAllColumns\032\037.mlflow.Lis" +
+      "tAllColumns.Response\"\224\001\362\206\031\217\001\n\"\n\004POST\022\024/m" +
+      "lflow/columns/list\032\004\010\002\020\000\n*\n\004POST\022\034/previ" +
+      "ew/mlflow/columns/list\032\004\010\002\020\000\n)\n\003GET\022\034/pr" +
+      "eview/mlflow/columns/list\032\004\010\002\020\000\020\001*\020List " +
+      "all columns\022\314\001\n\nsearchRuns\022\022.mlflow.Sear" +
+      "chRuns\032\033.mlflow.SearchRuns.Response\"\214\001\362\206" +
+      "\031\207\001\n!\n\004POST\022\023/mlflow/runs/search\032\004\010\002\020\000\n)" +
+      "\n\004POST\022\033/preview/mlflow/runs/search\032\004\010\002\020" +
+      "\000\n(\n\003GET\022\033/preview/mlflow/runs/search\032\004\010" +
+      "\002\020\000\020\001*\013Search Runs\022\260\001\n\rlistArtifacts\022\025.m" +
+      "lflow.ListArtifacts\032\036.mlflow.ListArtifac" +
+      "ts.Response\"h\362\206\031d\n#\n\003GET\022\026/mlflow/artifa" +
+      "cts/list\032\004\010\002\020\000\n+\n\003GET\022\036/preview/mlflow/a" +
+      "rtifacts/list\032\004\010\002\020\000\020\001*\016List Artifacts\022\307\001" +
+      "\n\020getMetricHistory\022\030.mlflow.GetMetricHis" +
+      "tory\032!.mlflow.GetMetricHistory.Response\"" +
+      "v\362\206\031r\n(\n\003GET\022\033/mlflow/metrics/get-histor" +
+      "y\032\004\010\002\020\000\n0\n\003GET\022#/preview/mlflow/metrics/" +
+      "get-history\032\004\010\002\020\000\020\001*\022Get Metric History\022" +
+      "\373\001\n\027updateArtifactsLocation\022\037.mlflow.Upd" +
+      "ateArtifactsLocation\032(.mlflow.UpdateArti" +
+      "factsLocation.Response\"\224\001\362\206\031\217\001\n3\n\003PUT\022&/" +
+      "mlflow/runs/update-artifacts-location\032\004\010" +
+      "\002\020\000\n;\n\003PUT\022./preview/mlflow/runs/update-" +
+      "artifacts-location\032\004\010\002\020\000\020\001*\031Update Artif" +
+      "acts Location\022\236\001\n\010logBatch\022\020.mlflow.LogB" +
+      "atch\032\031.mlflow.LogBatch.Response\"e\362\206\031a\n$\n" +
+      "\004POST\022\026/mlflow/runs/log-batch\032\004\010\002\020\000\n,\n\004P" +
+      "OST\022\036/preview/mlflow/runs/log-batch\032\004\010\002\020" +
+      "\000\020\001*\tLog BatchB\036\n\024org.mlflow.api.proto\220\001" +
+      "\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -49680,8 +51538,20 @@ public final class Service {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetRun_Response_descriptor,
         new java.lang.String[] { "Run", });
-    internal_static_mlflow_SearchRuns_descriptor =
+    internal_static_mlflow_ListAllColumns_descriptor =
       getDescriptor().getMessageTypes().get(24);
+    internal_static_mlflow_ListAllColumns_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_ListAllColumns_descriptor,
+        new java.lang.String[] { "ExperimentIds", });
+    internal_static_mlflow_ListAllColumns_Response_descriptor =
+      internal_static_mlflow_ListAllColumns_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_ListAllColumns_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_ListAllColumns_Response_descriptor,
+        new java.lang.String[] { "Attributes", "Metrics", "Params", "Tags", });
+    internal_static_mlflow_SearchRuns_descriptor =
+      getDescriptor().getMessageTypes().get(25);
     internal_static_mlflow_SearchRuns_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SearchRuns_descriptor,
@@ -49699,7 +51569,7 @@ public final class Service {
         internal_static_mlflow_SearchRuns_WhiteList_descriptor,
         new java.lang.String[] { "Fields", });
     internal_static_mlflow_ListArtifacts_descriptor =
-      getDescriptor().getMessageTypes().get(25);
+      getDescriptor().getMessageTypes().get(26);
     internal_static_mlflow_ListArtifacts_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_ListArtifacts_descriptor,
@@ -49711,13 +51581,13 @@ public final class Service {
         internal_static_mlflow_ListArtifacts_Response_descriptor,
         new java.lang.String[] { "RootUri", "Files", });
     internal_static_mlflow_FileInfo_descriptor =
-      getDescriptor().getMessageTypes().get(26);
+      getDescriptor().getMessageTypes().get(27);
     internal_static_mlflow_FileInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_FileInfo_descriptor,
         new java.lang.String[] { "Path", "IsDir", "FileSize", });
     internal_static_mlflow_GetMetricHistory_descriptor =
-      getDescriptor().getMessageTypes().get(27);
+      getDescriptor().getMessageTypes().get(28);
     internal_static_mlflow_GetMetricHistory_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetMetricHistory_descriptor,
@@ -49729,7 +51599,7 @@ public final class Service {
         internal_static_mlflow_GetMetricHistory_Response_descriptor,
         new java.lang.String[] { "Metrics", });
     internal_static_mlflow_LogBatch_descriptor =
-      getDescriptor().getMessageTypes().get(28);
+      getDescriptor().getMessageTypes().get(29);
     internal_static_mlflow_LogBatch_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogBatch_descriptor,
@@ -49741,7 +51611,7 @@ public final class Service {
         internal_static_mlflow_LogBatch_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_GetExperimentByName_descriptor =
-      getDescriptor().getMessageTypes().get(29);
+      getDescriptor().getMessageTypes().get(30);
     internal_static_mlflow_GetExperimentByName_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetExperimentByName_descriptor,
@@ -49753,7 +51623,7 @@ public final class Service {
         internal_static_mlflow_GetExperimentByName_Response_descriptor,
         new java.lang.String[] { "Experiment", });
     internal_static_mlflow_UpdateArtifactsLocation_descriptor =
-      getDescriptor().getMessageTypes().get(30);
+      getDescriptor().getMessageTypes().get(31);
     internal_static_mlflow_UpdateArtifactsLocation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_UpdateArtifactsLocation_descriptor,

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -346,6 +346,28 @@ service MlflowService {
     };
   }
 
+  // List all columns
+  //
+  rpc listAllColumns (ListAllColumns) returns (ListAllColumns.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/columns/list"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
+        path: "/preview/mlflow/columns/list"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "GET",
+        path: "/preview/mlflow/columns/list"
+        since { major: 2, minor: 0 },
+      }],
+      visibility: PUBLIC,
+      rpc_doc_title: "List all columns",
+    };
+  }
+
   // Search for runs that satisfy expressions. Search expressions can use :ref:`mlflowMetric` and
   // :ref:`mlflowParam` keys.
   //
@@ -916,6 +938,20 @@ message GetRun {
   message Response {
     // Run metadata (name, start time, etc) and data (metrics, params, and tags).
     optional Run run = 1;
+  }
+}
+
+message ListAllColumns {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // List of experiment IDs to search over.
+  repeated string experiment_ids = 1;
+
+  message Response {
+    repeated string attributes = 1;
+    repeated string metrics = 2;
+    repeated string params = 3;
+    repeated string tags = 4;
   }
 }
 

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb0\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aU\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12!\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfoB\x02\x18\x01:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xf5\x03\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x12\x37\n\x11metrics_whitelist\x18\x08 \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x12\x36\n\x10params_whitelist\x18\t \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x12\x34\n\x0etags_whitelist\x18\n \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x1aW\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12\x17\n\x0ftotal_run_count\x18\x03 \x01(\x05\x1a\x1b\n\tWhiteList\x12\x0e\n\x06\x66ields\x18\x01 \x03(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x17UpdateArtifactsLocation\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12$\n\x16new_artifacts_location\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xbe\x1f\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12\xc6\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xbc\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"n\xf2\x86\x19j\n%\n\x03GET\x12\x18/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\xb2\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"j\xf2\x86\x19\x66\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\xc6\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xcc\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"x\xf2\x86\x19t\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\xc6\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12\x9c\x01\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12\x9c\x01\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12\x9c\x01\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12\xa2\x01\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"c\xf2\x86\x19_\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12\xa4\x01\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12\xa6\x01\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xe1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"\x8f\x01\xf2\x86\x19\x8a\x01\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\n<\n\x04POST\x12./preview/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x92\x01\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"_\xf2\x86\x19[\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12\xa4\x01\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x88\x01\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"U\xf2\x86\x19Q\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xcc\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"\x8c\x01\xf2\x86\x19\x87\x01\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\xb0\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"h\xf2\x86\x19\x64\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\xc7\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"v\xf2\x86\x19r\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12\xfb\x01\n\x17updateArtifactsLocation\x12\x1f.mlflow.UpdateArtifactsLocation\x1a(.mlflow.UpdateArtifactsLocation.Response\"\x94\x01\xf2\x86\x19\x8f\x01\n3\n\x03PUT\x12&/mlflow/runs/update-artifacts-location\x1a\x04\x08\x02\x10\x00\n;\n\x03PUT\x12./preview/mlflow/runs/update-artifacts-location\x1a\x04\x08\x02\x10\x00\x10\x01*\x19Update Artifacts Location\x12\x9e\x01\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb0\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aU\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12!\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfoB\x02\x18\x01:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa4\x01\n\x0eListAllColumns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x1aM\n\x08Response\x12\x12\n\nattributes\x18\x01 \x03(\t\x12\x0f\n\x07metrics\x18\x02 \x03(\t\x12\x0e\n\x06params\x18\x03 \x03(\t\x12\x0c\n\x04tags\x18\x04 \x03(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xf5\x03\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x12\x37\n\x11metrics_whitelist\x18\x08 \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x12\x36\n\x10params_whitelist\x18\t \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x12\x34\n\x0etags_whitelist\x18\n \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x1aW\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x12\x17\n\x0ftotal_run_count\x18\x03 \x01(\x05\x1a\x1b\n\tWhiteList\x12\x0e\n\x06\x66ields\x18\x01 \x03(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x17UpdateArtifactsLocation\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12$\n\x16new_artifacts_location\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xa1!\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12\xc6\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xbc\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"n\xf2\x86\x19j\n%\n\x03GET\x12\x18/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\xb2\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"j\xf2\x86\x19\x66\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\xc6\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xcc\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"x\xf2\x86\x19t\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\xc6\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12\x9c\x01\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12\x9c\x01\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12\x9c\x01\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12\xa2\x01\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"c\xf2\x86\x19_\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12\xa4\x01\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12\xa6\x01\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xe1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"\x8f\x01\xf2\x86\x19\x8a\x01\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\n<\n\x04POST\x12./preview/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x92\x01\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"_\xf2\x86\x19[\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12\xa4\x01\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x88\x01\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"U\xf2\x86\x19Q\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xe0\x01\n\x0elistAllColumns\x12\x16.mlflow.ListAllColumns\x1a\x1f.mlflow.ListAllColumns.Response\"\x94\x01\xf2\x86\x19\x8f\x01\n\"\n\x04POST\x12\x14/mlflow/columns/list\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/columns/list\x1a\x04\x08\x02\x10\x00\n)\n\x03GET\x12\x1c/preview/mlflow/columns/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List all columns\x12\xcc\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"\x8c\x01\xf2\x86\x19\x87\x01\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\xb0\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"h\xf2\x86\x19\x64\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\xc7\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"v\xf2\x86\x19r\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12\xfb\x01\n\x17updateArtifactsLocation\x12\x1f.mlflow.UpdateArtifactsLocation\x1a(.mlflow.UpdateArtifactsLocation.Response\"\x94\x01\xf2\x86\x19\x8f\x01\n3\n\x03PUT\x12&/mlflow/runs/update-artifacts-location\x1a\x04\x08\x02\x10\x00\n;\n\x03PUT\x12./preview/mlflow/runs/update-artifacts-location\x1a\x04\x08\x02\x10\x00\x10\x01*\x19Update Artifacts Location\x12\x9e\x01\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _VIEWTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4459,
-  serialized_end=4513,
+  serialized_start=4626,
+  serialized_end=4680,
 )
 _sym_db.RegisterEnumDescriptor(_VIEWTYPE)
 
@@ -84,8 +84,8 @@ _SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4515,
-  serialized_end=4588,
+  serialized_start=4682,
+  serialized_end=4755,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCETYPE)
 
@@ -119,8 +119,8 @@ _RUNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4590,
-  serialized_end=4667,
+  serialized_start=4757,
+  serialized_end=4834,
 )
 _sym_db.RegisterEnumDescriptor(_RUNSTATUS)
 
@@ -1624,6 +1624,88 @@ _GETRUN = _descriptor.Descriptor(
 )
 
 
+_LISTALLCOLUMNS_RESPONSE = _descriptor.Descriptor(
+  name='Response',
+  full_name='mlflow.ListAllColumns.Response',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='attributes', full_name='mlflow.ListAllColumns.Response.attributes', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='metrics', full_name='mlflow.ListAllColumns.Response.metrics', index=1,
+      number=2, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='params', full_name='mlflow.ListAllColumns.Response.params', index=2,
+      number=3, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='tags', full_name='mlflow.ListAllColumns.Response.tags', index=3,
+      number=4, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3115,
+  serialized_end=3192,
+)
+
+_LISTALLCOLUMNS = _descriptor.Descriptor(
+  name='ListAllColumns',
+  full_name='mlflow.ListAllColumns',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='experiment_ids', full_name='mlflow.ListAllColumns.experiment_ids', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_LISTALLCOLUMNS_RESPONSE, ],
+  enum_types=[
+  ],
+  serialized_options=_b('\342?(\n&com.databricks.rpc.RPC[$this.Response]'),
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3073,
+  serialized_end=3237,
+)
+
+
 _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   name='Response',
   full_name='mlflow.SearchRuns.Response',
@@ -1664,8 +1746,8 @@ _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3413,
-  serialized_end=3500,
+  serialized_start=3580,
+  serialized_end=3667,
 )
 
 _SEARCHRUNS_WHITELIST = _descriptor.Descriptor(
@@ -1694,8 +1776,8 @@ _SEARCHRUNS_WHITELIST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3502,
-  serialized_end=3529,
+  serialized_start=3669,
+  serialized_end=3696,
 )
 
 _SEARCHRUNS = _descriptor.Descriptor(
@@ -1780,8 +1862,8 @@ _SEARCHRUNS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3073,
-  serialized_end=3574,
+  serialized_start=3240,
+  serialized_end=3741,
 )
 
 
@@ -1818,8 +1900,8 @@ _LISTARTIFACTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3642,
-  serialized_end=3703,
+  serialized_start=3809,
+  serialized_end=3870,
 )
 
 _LISTARTIFACTS = _descriptor.Descriptor(
@@ -1862,8 +1944,8 @@ _LISTARTIFACTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3577,
-  serialized_end=3748,
+  serialized_start=3744,
+  serialized_end=3915,
 )
 
 
@@ -1907,8 +1989,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3750,
-  serialized_end=3809,
+  serialized_start=3917,
+  serialized_end=3976,
 )
 
 
@@ -1938,8 +2020,8 @@ _GETMETRICHISTORY_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3892,
-  serialized_end=3935,
+  serialized_start=4059,
+  serialized_end=4102,
 )
 
 _GETMETRICHISTORY = _descriptor.Descriptor(
@@ -1982,8 +2064,8 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3812,
-  serialized_end=3980,
+  serialized_start=3979,
+  serialized_end=4147,
 )
 
 
@@ -2057,8 +2139,8 @@ _LOGBATCH = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3983,
-  serialized_end=4160,
+  serialized_start=4150,
+  serialized_end=4327,
 )
 
 
@@ -2118,8 +2200,8 @@ _GETEXPERIMENTBYNAME = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4163,
-  serialized_end=4312,
+  serialized_start=4330,
+  serialized_end=4479,
 )
 
 
@@ -2179,8 +2261,8 @@ _UPDATEARTIFACTSLOCATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4315,
-  serialized_end=4457,
+  serialized_start=4482,
+  serialized_end=4624,
 )
 
 _RUN.fields_by_name['info'].message_type = _RUNINFO
@@ -2215,6 +2297,7 @@ _SETTAG_RESPONSE.containing_type = _SETTAG
 _DELETETAG_RESPONSE.containing_type = _DELETETAG
 _GETRUN_RESPONSE.fields_by_name['run'].message_type = _RUN
 _GETRUN_RESPONSE.containing_type = _GETRUN
+_LISTALLCOLUMNS_RESPONSE.containing_type = _LISTALLCOLUMNS
 _SEARCHRUNS_RESPONSE.fields_by_name['runs'].message_type = _RUN
 _SEARCHRUNS_RESPONSE.containing_type = _SEARCHRUNS
 _SEARCHRUNS_WHITELIST.containing_type = _SEARCHRUNS
@@ -2257,6 +2340,7 @@ DESCRIPTOR.message_types_by_name['SetExperimentTag'] = _SETEXPERIMENTTAG
 DESCRIPTOR.message_types_by_name['SetTag'] = _SETTAG
 DESCRIPTOR.message_types_by_name['DeleteTag'] = _DELETETAG
 DESCRIPTOR.message_types_by_name['GetRun'] = _GETRUN
+DESCRIPTOR.message_types_by_name['ListAllColumns'] = _LISTALLCOLUMNS
 DESCRIPTOR.message_types_by_name['SearchRuns'] = _SEARCHRUNS
 DESCRIPTOR.message_types_by_name['ListArtifacts'] = _LISTARTIFACTS
 DESCRIPTOR.message_types_by_name['FileInfo'] = _FILEINFO
@@ -2565,6 +2649,21 @@ GetRun = _reflection.GeneratedProtocolMessageType('GetRun', (_message.Message,),
 _sym_db.RegisterMessage(GetRun)
 _sym_db.RegisterMessage(GetRun.Response)
 
+ListAllColumns = _reflection.GeneratedProtocolMessageType('ListAllColumns', (_message.Message,), dict(
+
+  Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
+    DESCRIPTOR = _LISTALLCOLUMNS_RESPONSE,
+    __module__ = 'service_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.ListAllColumns.Response)
+    ))
+  ,
+  DESCRIPTOR = _LISTALLCOLUMNS,
+  __module__ = 'service_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.ListAllColumns)
+  ))
+_sym_db.RegisterMessage(ListAllColumns)
+_sym_db.RegisterMessage(ListAllColumns.Response)
+
 SearchRuns = _reflection.GeneratedProtocolMessageType('SearchRuns', (_message.Message,), dict(
 
   Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
@@ -2708,6 +2807,7 @@ _DELETETAG.fields_by_name['run_id']._options = None
 _DELETETAG.fields_by_name['key']._options = None
 _DELETETAG._options = None
 _GETRUN._options = None
+_LISTALLCOLUMNS._options = None
 _SEARCHRUNS._options = None
 _LISTARTIFACTS._options = None
 _GETMETRICHISTORY.fields_by_name['metric_key']._options = None
@@ -2725,8 +2825,8 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=4670,
-  serialized_end=8700,
+  serialized_start=4837,
+  serialized_end=9094,
   methods=[
   _descriptor.MethodDescriptor(
     name='getExperimentByName',
@@ -2882,9 +2982,18 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     serialized_options=_b('\362\206\031Q\n\035\n\003GET\022\020/mlflow/runs/get\032\004\010\002\020\000\n%\n\003GET\022\030/preview/mlflow/runs/get\032\004\010\002\020\000\020\001*\007Get Run'),
   ),
   _descriptor.MethodDescriptor(
+    name='listAllColumns',
+    full_name='mlflow.MlflowService.listAllColumns',
+    index=17,
+    containing_service=None,
+    input_type=_LISTALLCOLUMNS,
+    output_type=_LISTALLCOLUMNS_RESPONSE,
+    serialized_options=_b('\362\206\031\217\001\n\"\n\004POST\022\024/mlflow/columns/list\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/columns/list\032\004\010\002\020\000\n)\n\003GET\022\034/preview/mlflow/columns/list\032\004\010\002\020\000\020\001*\020List all columns'),
+  ),
+  _descriptor.MethodDescriptor(
     name='searchRuns',
     full_name='mlflow.MlflowService.searchRuns',
-    index=17,
+    index=18,
     containing_service=None,
     input_type=_SEARCHRUNS,
     output_type=_SEARCHRUNS_RESPONSE,
@@ -2893,7 +3002,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='listArtifacts',
     full_name='mlflow.MlflowService.listArtifacts',
-    index=18,
+    index=19,
     containing_service=None,
     input_type=_LISTARTIFACTS,
     output_type=_LISTARTIFACTS_RESPONSE,
@@ -2902,7 +3011,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='getMetricHistory',
     full_name='mlflow.MlflowService.getMetricHistory',
-    index=19,
+    index=20,
     containing_service=None,
     input_type=_GETMETRICHISTORY,
     output_type=_GETMETRICHISTORY_RESPONSE,
@@ -2911,7 +3020,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='updateArtifactsLocation',
     full_name='mlflow.MlflowService.updateArtifactsLocation',
-    index=20,
+    index=21,
     containing_service=None,
     input_type=_UPDATEARTIFACTSLOCATION,
     output_type=_UPDATEARTIFACTSLOCATION_RESPONSE,
@@ -2920,7 +3029,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='logBatch',
     full_name='mlflow.MlflowService.logBatch',
-    index=21,
+    index=22,
     containing_service=None,
     input_type=_LOGBATCH,
     output_type=_LOGBATCH_RESPONSE,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -15,7 +15,7 @@ from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperi
     GetRun, SearchRuns, ListArtifacts, GetMetricHistory, CreateRun, \
     UpdateRun, LogMetric, LogParam, SetTag, ListExperiments, \
     DeleteExperiment, RestoreExperiment, RestoreRun, DeleteRun, UpdateExperiment, LogBatch, \
-    DeleteTag, SetExperimentTag, GetExperimentByName, UpdateArtifactsLocation
+    DeleteTag, SetExperimentTag, GetExperimentByName, UpdateArtifactsLocation, ListAllColumns
 from mlflow.protos.model_registry_pb2 import ModelRegistryService, CreateRegisteredModel, \
     UpdateRegisteredModel, DeleteRegisteredModel, ListRegisteredModels, GetRegisteredModelDetails, \
     GetLatestVersions, CreateModelVersion, UpdateModelVersion, DeleteModelVersion, \
@@ -360,6 +360,17 @@ def _get_run():
 
 
 @catch_mlflow_exception
+def _list_all_columns():
+    request_message = _get_request_message(ListAllColumns())
+    experiment_ids = request_message.experiment_ids
+    columns = _get_tracking_store().list_all_columns(experiment_ids)
+    response_message = columns.to_proto()
+    response = Response(mimetype='application/json')
+    response.set_data(message_to_json(response_message))
+    return response
+
+
+@catch_mlflow_exception
 def _search_runs():
     request_message = _get_request_message(SearchRuns())
     response_message = SearchRuns.Response()
@@ -667,6 +678,7 @@ HANDLERS = {
     LogBatch: _log_batch,
     GetRun: _get_run,
     SearchRuns: _search_runs,
+    ListAllColumns: _list_all_columns,
     ListArtifacts: _list_artifacts,
     GetMetricHistory: _get_metric_history,
     ListExperiments: _list_experiments,

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -205,6 +205,10 @@ class AbstractStore:
         """
         pass
 
+    @abstractmethod
+    def list_all_columns(self, experiment_ids):
+        pass
+
     def search_runs(self, experiment_ids, filter_string, run_view_type,
                     max_results=SEARCH_MAX_RESULTS_DEFAULT, order_by=None, page_token=None,
                     metrics_whitelist=None, params_whitelist=None, tags_whitelist=None):

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -1,11 +1,12 @@
 from mlflow.entities import Experiment, Run, RunInfo, Metric, ViewType
+from mlflow.entities.columns import Columns
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperiment, \
     GetRun, SearchRuns, ListExperiments, GetMetricHistory, LogMetric, LogParam, SetTag, \
     UpdateRun, CreateRun, DeleteRun, RestoreRun, DeleteExperiment, RestoreExperiment, \
     UpdateExperiment, LogBatch, DeleteTag, SetExperimentTag, GetExperimentByName, \
-    UpdateArtifactsLocation
+    UpdateArtifactsLocation, ListAllColumns
 from mlflow.store.tracking.abstract_store import AbstractStore
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import call_endpoint, extract_api_info_for_service
@@ -187,6 +188,13 @@ class RestStore(AbstractStore):
             run_uuid=run_id, run_id=run_id, metric_key=metric_key))
         response_proto = self._call_endpoint(GetMetricHistory, req_body)
         return [Metric.from_proto(metric) for metric in response_proto.metrics]
+
+    def list_all_columns(self, experiment_ids):
+        experiment_ids = [str(experiment_id) for experiment_id in experiment_ids]
+        lac = ListAllColumns(experiment_ids=experiment_ids)
+        req_body = message_to_json(lac)
+        response_proto = self._call_endpoint(ListAllColumns, req_body)
+        return Columns.from_proto(response_proto)
 
     def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by,
                      page_token, metrics_whitelist, params_whitelist, tags_whitelist):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -6,7 +6,7 @@ import pytest
 
 import os
 import mlflow
-from mlflow.entities import ViewType
+from mlflow.entities import ViewType, Columns
 from mlflow.entities.model_registry import RegisteredModel, RegisteredModelDetailed, \
     ModelVersionDetailed, ModelVersion
 from mlflow.exceptions import MlflowException
@@ -16,10 +16,10 @@ from mlflow.server.handlers import get_endpoints, _create_experiment, _get_reque
     _update_registered_model, _delete_registered_model, _get_registered_model_details, \
     _list_registered_models, _get_latest_versions, _create_model_version, _update_model_version, \
     _delete_model_version, _get_model_version_download_uri, _get_model_version_stages, \
-    _search_model_versions, _get_model_version_details
+    _search_model_versions, _get_model_version_details, _list_all_columns
 from mlflow.server import BACKEND_STORE_URI_ENV_VAR
 from mlflow.store.entities.paged_list import PagedList
-from mlflow.protos.service_pb2 import CreateExperiment, SearchRuns
+from mlflow.protos.service_pb2 import CreateExperiment, SearchRuns, ListAllColumns
 from mlflow.protos.model_registry_pb2 import CreateRegisteredModel, UpdateRegisteredModel, \
     DeleteRegisteredModel, ListRegisteredModels, GetRegisteredModelDetails, GetLatestVersions, \
     CreateModelVersion, UpdateModelVersion, DeleteModelVersion, GetModelVersionDetails, \
@@ -132,6 +132,23 @@ def test_can_parse_json_string():
     request.get_json.return_value = '{"name": "hello2"}'
     msg = _get_request_message(CreateExperiment(), flask_request=request)
     assert msg.name == "hello2"
+
+
+def test_list_all_columns(mock_get_request_message, mock_tracking_store):
+    """
+    List all columns
+    """
+    mock_get_request_message.return_value = ListAllColumns(experiment_ids=["0"])
+    mock_tracking_store.list_all_columns.return_value = Columns(
+        tags=["tag1", "tag2"],
+        metrics=["metric1", "metric2"],
+        params=["param1", "param2"],
+    )
+    resp = _list_all_columns()
+    json_response = json.loads(resp.get_data())
+    assert set(json_response["tags"]) == {"tag1", "tag2"}
+    assert set(json_response["params"]) == {"param1", "param2"}
+    assert set(json_response["metrics"]) == {"metric1", "metric2"}
 
 
 def test_search_runs_default_view_type(mock_get_request_message, mock_tracking_store):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -416,6 +416,23 @@ class TestFileStore(unittest.TestCase):
         assert len(self._search(fs, self.experiments[0])) == 2
         assert len(self._search(fs, self.experiments[0], run_view_type=ViewType.DELETED_ONLY)) == 0
 
+    def test_list_columns(self):
+        fs = FileStore(self.test_root)
+        experiment_id = fs.create_experiment("test_list_columns", None)
+        r1 = fs.create_run(experiment_id, 'user', 0, []).info.run_id
+        r2 = fs.create_run(experiment_id, 'user', 0, []).info.run_id
+        fs.log_metric(r1, Metric("metric1", 10, 1232, 0))
+        fs.log_metric(r2, Metric("metric2", 10, 1231, 0))
+        fs.set_tag(r1, RunTag("tag1", "value1!"))
+        fs.set_tag(r2, RunTag("tag2", "value2!"))
+        fs.log_param(r1, Param("param1", "Value"))
+        fs.log_param(r2, Param("param2", "Value"))
+
+        columns = fs.list_all_columns(experiment_ids=[experiment_id])
+        assert set(columns.tags) == {"tag1", "tag2"}
+        assert set(columns.params) == {"param1", "param2"}
+        assert set(columns.metrics) == {"metric1", "metric2"}
+
     def test_search_tags(self):
         fs = FileStore(self.test_root)
         experiment_id = self.experiments[0]

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1183,6 +1183,25 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert [r.info.run_id for r in result] == runs[8:]
         assert result.token is None
 
+    def test_list_all_columns(self):
+        experiment_id = self._experiment_factory('list_all_columns')
+        r1 = self._run_factory(self._get_run_configs(experiment_id)).info.run_id
+        r2 = self._run_factory(self._get_run_configs(experiment_id)).info.run_id
+
+        self.store.set_tag(r1, entities.RunTag('tag1', 'p_val'))
+        self.store.set_tag(r2, entities.RunTag('tag2', 'p_val'))
+
+        self.store.log_param(r1, entities.Param('param1', 'p_val'))
+        self.store.log_param(r2, entities.Param('param2', 'p_val'))
+
+        self.store.log_metric(r1, entities.Metric("metric1", 1.0, 1, 0))
+        self.store.log_metric(r2, entities.Metric("metric2", 1.0, 1, 0))
+
+        columns = self.store.list_all_columns(experiment_ids=[experiment_id])
+        assert set(columns.tags) == {"tag1", "tag2"}
+        assert set(columns.params) == {"param1", "param2"}
+        assert set(columns.metrics) == {"metric1", "metric2"}
+
     def test_log_batch(self):
         experiment_id = self._experiment_factory('log_batch')
         run_id = self._run_factory(self._get_run_configs(experiment_id)).info.run_id


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a list_all_columns function to store and handler
it takes as argument a list of experiment id
it returns the metrics, tags, params and attributes names
present for these experiments

this is particularly useful in an UI proposing to choose
columns

## How is this patch tested?

* test in sql alchemy store
* test in file store
* test in handler

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

add list_all_columns in API

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [x] API
- [x] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
