### PR TITLE
Master sync 21/11

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -299,6 +299,18 @@ Models with the ``onnx`` flavor in native ONNX format.
 
 For more information, see :py:mod:`mlflow.onnx` and `<http://onnx.ai/>`_.
 
+MXNet Gluon (``gluon``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The ``gluon`` model flavor enables logging of `Gluon models
+<https://mxnet.incubator.apache.org/api/python/docs/api/gluon/index.html>`_ in MLflow format via
+the :py:func:`mlflow.gluon.save_model()` and :py:func:`mlflow.gluon.log_model()` methods. These
+methods also add the ``python_function`` flavor to the MLflow Models that they produce, allowing the
+models to be interpreted as generic Python functions for inference via
+:py:func:`mlflow.pyfunc.load_model()`. You can also use the :py:func:`mlflow.gluon.load_model()`
+method to load MLflow Models with the ``gluon`` flavor in native Gluon format.
+
+For more information, see :py:mod:`mlflow.gluon`.
+
 Model Customization
 -------------------
 

--- a/docs/source/python_api/mlflow.gluon.rst
+++ b/docs/source/python_api/mlflow.gluon.rst
@@ -1,0 +1,7 @@
+mlflow.gluon
+==============
+
+.. automodule:: mlflow.gluon
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -240,6 +240,22 @@ If a run exists when ``autolog()`` captures data, MLflow will log to that run an
 **Note**: this feature is experimental - the API and format of the logged data are subject to change.
 
 
+Automatic Logging from Gluon (experimental)
+==================================================================
+Call :py:func:`mlflow.gluon.autolog` before your training code to enable automatic logging of metrics and parameters without the need for explicit
+log statements. See example usages with `Gluon <https://github.com/mlflow/mlflow/tree/master/examples/gluon>`_ .
+
+Autologging captures the following information:
+
++------------------+--------------------------------------------------------+----------------------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------------+
+| Framework        | Metrics                                                | Parameters                                               | Tags          | Artifacts                                                                                                                     |
++------------------+--------------------------------------------------------+----------------------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------------+
+| Gluon            | Training loss; validation loss; user-specified metrics | Number of layers; optimizer name; learning rate; epsilon | --            | `MLflow Model <https://mlflow.org/docs/latest/models.html>`_ (Gluon model); on training end                                   |
++------------------+--------------------------------------------------------+----------------------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------------+
+
+**Note**: this feature is experimental - the API and format of the logged data are subject to change.
+
+
 .. _organizing_runs_in_experiments:
 
 Organizing Runs in Experiments

--- a/examples/gluon/train.py
+++ b/examples/gluon/train.py
@@ -1,0 +1,52 @@
+from mxnet import gluon, init
+from mxnet.gluon import Trainer
+from mxnet.gluon.contrib import estimator
+from mxnet.gluon.data.vision import datasets, transforms
+from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
+from mxnet.gluon.nn import HybridSequential, Dense, Flatten, MaxPool2D, Conv2D
+from mxnet.metric import Accuracy
+
+# The following import and function call are the only additions to code required
+# to automatically log metrics and parameters to MLflow.
+import mlflow.gluon
+
+mlflow.gluon.autolog()
+
+mnist_train = datasets.FashionMNIST(train=True)
+X, y = mnist_train[0]
+
+text_labels = ["t-shirt", "trouser", "pullover", "dress", "coat", "sandal", "shirt", "sneaker", "bag", "ankle boot"]
+X, y = mnist_train[0:10]
+
+transformer = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize(0.13, 0.31)])
+mnist_train = mnist_train.transform_first(transformer)
+
+batch_size = 256
+train_data = gluon.data.DataLoader(
+    mnist_train, batch_size=batch_size, shuffle=True, num_workers=4)
+
+mnist_valid = gluon.data.vision.FashionMNIST(train=False)
+valid_data = gluon.data.DataLoader(
+    mnist_valid.transform_first(transformer),
+    batch_size=batch_size, num_workers=4)
+
+# Only hybrid based networks can be exported
+net = HybridSequential()
+net.add(Conv2D(channels=6, kernel_size=5, activation="relu"),
+        MaxPool2D(pool_size=2, strides=2),
+        Conv2D(channels=16, kernel_size=3, activation="relu"),
+        MaxPool2D(pool_size=2, strides=2),
+        Flatten(),
+        Dense(120, activation="relu"),
+        Dense(84, activation="relu"),
+        Dense(10))
+net.initialize(init=init.Xavier())
+# Only after hybridization a model can be exported with architecture included
+net.hybridize()
+
+trainer = Trainer(net.collect_params(), "sgd", {"learning_rate": 0.1})
+
+est = estimator.Estimator(net=net, loss=SoftmaxCrossEntropyLoss(), metrics=Accuracy(), trainer=trainer)
+est.fit(train_data=train_data, epochs=2, val_data=valid_data)

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -1,0 +1,277 @@
+import os
+
+import gorilla
+import mxnet as mx
+import pandas as pd
+import yaml
+from mxnet import gluon
+from mxnet import sym
+from mxnet.gluon.contrib.estimator import Estimator, EpochEnd, TrainBegin, TrainEnd
+from mxnet.gluon.nn import HybridSequential
+
+import mlflow
+from mlflow import pyfunc
+from mlflow.exceptions import MlflowException
+from mlflow.models import Model
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils import experimental
+from mlflow.utils.autologging_utils import try_mlflow_log
+from mlflow.utils.environment import _mlflow_conda_env
+
+FLAVOR_NAME = "gluon"
+_MODEL_SAVE_PATH = "net"
+
+
+@experimental
+def load_model(model_uri, ctx):
+    """
+    Load a Gluon model from a local file or a run.
+
+    :param model_uri: The location, in URI format, of the MLflow model. For example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see
+                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
+                      artifact-locations>`_.
+    :param ctx: Either CPU or GPU.
+
+    :return: A Gluon model instance.
+
+    >>> # Load persisted model as a Gluon model, make inferences against an NDArray
+    >>> model = mlflow.gluon.load_model("runs:/" + gluon_random_data_run.info.run_id + "/model")
+    >>> model(nd.array(np.random.rand(1000, 1, 32)))
+    """
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+
+    model_arch_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
+    model_params_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-0000.params"
+    symbol = sym.load(model_arch_path)
+    inputs = sym.var('data', dtype='float32')
+    net = gluon.SymbolBlock(symbol, inputs)
+    net.collect_params().load(model_params_path, ctx)
+    return net
+
+
+class _GluonModelWrapper:
+    def __init__(self, gluon_model):
+        self.gluon_model = gluon_model
+
+    def predict(self, df):
+        """
+        :param df: A Pandas DataFrame containing input array values. A DataFrame input,
+                   `df` is converted to an MXNet ndarray via `ndarray = mx.nd.array(df.values)`.
+        :return: A Pandas DataFrame containing output array values. The underlying MXNet array
+                 can be extracted from the output DataFrame as `ndarray = mx.nd.array(df.values)`.
+        """
+        ndarray = mx.nd.array(df.values)
+        return pd.DataFrame(self.gluon_model(ndarray).asnumpy())
+
+
+def _load_pyfunc(path):
+    """
+    Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``gluon`` flavor.
+    """
+    m = load_model(path, mx.current_context())
+    return _GluonModelWrapper(m)
+
+
+@experimental
+def save_model(gluon_model, path, mlflow_model=Model(), conda_env=None):
+    """
+    Save a Gluon model to a path on the local file system.
+
+    :param gluon_model: Gluon model to be saved. Must be already hybridized.
+    :param path: Local path where the model is to be saved.
+    :param mlflow_model: MLflow model config this flavor is being added to.
+    :param conda_env: Either a dictionary representation of a Conda environment or
+                      the path to a Conda environment yaml file.
+                      If provided, this decribes the environment this model should be
+                      run in. At minimum, it should specify the dependencies
+                      contained in :func:`get_default_conda_env()`. If ``None``, the default
+                      :func:`mlflow.gluon.get_default_conda_env()` environment is added to
+                      the model. The following is an *example* dictionary representation of a
+                      Conda environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0',
+                                'mxnet=1.5.0'
+                            ]
+                        }
+
+    >>> from mxnet.gluon import Trainer
+    >>> from mxnet.gluon.contrib import estimator
+    >>> from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
+    >>> from mxnet.gluon.nn import HybridSequential
+    >>> from mxnet.metric import Accuracy
+    >>> import mlflow
+    >>> # Build, compile, and train your model
+    >>> gluon_model_path = ...
+    >>> net = HybridSequential()
+    >>> with net.name_scope():
+    >>> ...
+    >>> net.hybridize()
+    >>> net.collect_params().initialize()
+    >>> softmax_loss = SoftmaxCrossEntropyLoss()
+    >>> trainer = Trainer(net.collect_params())
+    >>> est = estimator.Estimator(net=net, loss=softmax_loss, metrics=Accuracy(), trainer=trainer)
+    >>> est.fit(train_data=train_data, epochs=100, val_data=validation_data)
+    ... # Save the model as an MLflow Model
+    >>> mlflow.gluon.save_model(net, gluon_model_path)
+    """
+    path = os.path.abspath(path)
+    if os.path.exists(path):
+        raise MlflowException("Path '{}' already exists".format(path))
+    data_subpath = "data"
+    data_path = os.path.join(path, data_subpath)
+    os.makedirs(data_path)
+    # The epoch argument of the export method does not play any role in selecting
+    # a specific epoch's paramaters, and is there only for display purposes.
+    gluon_model.export(os.path.join(data_path, _MODEL_SAVE_PATH))
+    with open(os.path.join(path, "architecture.txt"), "w") as fp:
+        fp.write(str(gluon_model))
+    conda_env_subpath = "conda.yaml"
+    if conda_env is None:
+        conda_env = get_default_conda_env()
+    elif not isinstance(conda_env, dict):
+        with open(conda_env, "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.gluon", env=conda_env_subpath)
+    mlflow_model.save(os.path.join(path, "MLmodel"))
+
+
+def get_default_conda_env():
+    """
+    :return: The default Conda environment for MLflow Models produced by calls to
+             :func:`save_model()` and :func:`log_model()`.
+    """
+    pip_deps = ["mxnet=={}".format(mx.__version__)]
+
+    return _mlflow_conda_env(additional_pip_deps=pip_deps)
+
+
+@experimental
+def log_model(gluon_model, artifact_path, conda_env=None):
+    """
+    Log a Gluon model as an MLflow artifact for the current run.
+
+    :param gluon_model: Gluon model to be saved. Must be already hybridized.
+    :param artifact_path: Run-relative artifact path.
+    :param conda_env: Either a dictionary representation of a Conda environment or
+                      the path to a Conda environment yaml file.
+                      If provided, this decribes the environment this model should be
+                      run in. At minimum, it should specify the dependencies
+                      contained in :func:`get_default_conda_env()`. If ``None``, the default
+                      :func:`mlflow.gluon.get_default_conda_env()` environment is added to
+                      the model. The following is an *example* dictionary representation of a
+                      Conda environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0',
+                                'mxnet=1.5.0'
+                            ]
+                        }
+
+    >>> from mxnet.gluon import Trainer
+    >>> from mxnet.gluon.contrib import estimator
+    >>> from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
+    >>> from mxnet.gluon.nn import HybridSequential
+    >>> from mxnet.metric import Accuracy
+    >>> import mlflow
+    >>> # Build, compile, and train your model
+    >>> net = HybridSequential()
+    >>> with net.name_scope():
+    >>> ...
+    >>> net.hybridize()
+    >>> net.collect_params().initialize()
+    >>> softmax_loss = SoftmaxCrossEntropyLoss()
+    >>> trainer = Trainer(net.collect_params())
+    >>> est = estimator.Estimator(net=net, loss=softmax_loss, metrics=Accuracy(), trainer=trainer)
+    >>> # Log metrics and log the model
+    >>> with mlflow.start_run() as run:
+    >>>   est.fit(train_data=train_data, epochs=100, val_data=validation_data)
+    >>>   mlflow.gluon.log_model(net, "model")
+    """
+    Model.log(artifact_path=artifact_path, flavor=mlflow.gluon, gluon_model=gluon_model,
+              conda_env=conda_env)
+
+
+@experimental
+def autolog():
+    """
+    Enable automatic logging from Gluon to MLflow.
+    Logs loss and any other metrics specified in the fit
+    function, and optimizer data as parameters. Model checkpoints
+    are logged as artifacts to a 'models' directory.
+    """
+
+    class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin):
+        def __init__(self):
+            self.current_epoch = 0
+
+        def epoch_end(self, estimator, *args, **kwargs):
+            logs = {}
+            for metric in estimator.train_metrics:
+                metric_name, metric_val = metric.get()
+                logs[metric_name] = metric_val
+            for metric in estimator.val_metrics:
+                metric_name, metric_val = metric.get()
+                logs[metric_name] = metric_val
+            try_mlflow_log(mlflow.log_metrics, logs, step=self.current_epoch)
+            self.current_epoch += 1
+
+        def train_begin(self, estimator, *args, **kwargs):
+            try_mlflow_log(mlflow.log_param, "num_layers", len(estimator.net))
+            if estimator.max_epoch is not None:
+                try_mlflow_log(mlflow.log_param, "epochs", estimator.max_epoch)
+            if estimator.max_batch is not None:
+                try_mlflow_log(mlflow.log_param, "batches", estimator.max_batch)
+            try_mlflow_log(mlflow.log_param, "optimizer_name",
+                           type(estimator.trainer.optimizer).__name__)
+            if hasattr(estimator.trainer.optimizer, "lr"):
+                try_mlflow_log(mlflow.log_param, "learning_rate",
+                               estimator.trainer.optimizer.lr)
+            if hasattr(estimator.trainer.optimizer, "epsilon"):
+                try_mlflow_log(mlflow.log_param, "epsilon",
+                               estimator.trainer.optimizer.epsilon)
+
+        def train_end(self, estimator, *args, **kwargs):
+            if isinstance(estimator.net, HybridSequential):
+                try_mlflow_log(log_model, estimator.net, artifact_path="model")
+
+    @gorilla.patch(Estimator)
+    def fit(self, *args, **kwargs):
+        if not mlflow.active_run():
+            auto_end_run = True
+        else:
+            auto_end_run = False
+
+        original = gorilla.get_original_attribute(Estimator, "fit")
+        if len(args) >= 4:
+            l = list(args)
+            l[3] += [__MLflowGluonCallback()]
+            args = tuple(l)
+        elif "event_handlers" in kwargs:
+            kwargs["event_handlers"] += [__MLflowGluonCallback()]
+        else:
+            kwargs["event_handlers"] = [__MLflowGluonCallback()]
+        result = original(self, *args, **kwargs)
+        if auto_end_run:
+            mlflow.end_run()
+        return result
+
+    settings = gorilla.Settings(allow_hit=True, store_hit=True)
+    gorilla.apply(gorilla.Patch(Estimator, "fit", fit, settings=settings))

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -1,0 +1,189 @@
+import os
+import warnings
+import yaml
+
+import mxnet as mx
+import mxnet.ndarray as nd
+import numpy as np
+import pandas as pd
+import pytest
+from mxnet import context as ctx
+from mxnet.gluon import Trainer
+from mxnet.gluon.contrib.estimator import estimator
+from mxnet.gluon.data import DataLoader
+from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
+from mxnet.gluon.nn import HybridSequential, Dense
+from mxnet.metric import Accuracy
+
+import mlflow
+import mlflow.gluon
+import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
+from mlflow import pyfunc
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.model_utils import _get_flavor_configuration
+
+from tests.helper_functions import pyfunc_serve_and_score_model
+
+
+@pytest.fixture
+def model_path(tmpdir):
+    return os.path.join(tmpdir.strpath, "model")
+
+
+@pytest.fixture
+def gluon_custom_env(tmpdir):
+    conda_env = os.path.join(str(tmpdir), "conda_env.yml")
+    _mlflow_conda_env(
+        conda_env,
+        additional_conda_deps=["mxnet", "pytest"])
+    return conda_env
+
+
+@pytest.fixture(scope="module")
+def model_data():
+    mnist = mx.test_utils.get_mnist()
+    train_data = nd.array(mnist["train_data"].reshape(-1, 784))
+    train_label = nd.array(mnist["train_label"])
+    test_data = nd.array(mnist["test_data"].reshape(-1, 784))
+    return train_data, train_label, test_data
+
+
+@pytest.fixture(scope="module")
+def gluon_model(model_data):
+    train_data, train_label, _ = model_data
+    train_data_loader = DataLoader(list(zip(train_data, train_label)),
+                                   batch_size=128, last_batch="discard")
+    model = HybridSequential()
+    model.add(Dense(128, activation="relu"))
+    model.add(Dense(64, activation="relu"))
+    model.add(Dense(10))
+    model.initialize()
+    model.hybridize()
+    trainer = Trainer(model.collect_params(), "adam",
+                      optimizer_params={"learning_rate": .001, "epsilon": 1e-07})
+    est = estimator.Estimator(net=model, loss=SoftmaxCrossEntropyLoss(),
+                              metrics=Accuracy(), trainer=trainer)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        est.fit(train_data_loader, epochs=3)
+    return model
+
+
+@pytest.mark.large
+def test_model_save_load(gluon_model, model_data, model_path):
+    _, _, test_data = model_data
+    expected = nd.argmax(gluon_model(test_data), axis=1)
+
+    mlflow.gluon.save_model(gluon_model, model_path)
+    # Loading Gluon model
+    model_loaded = mlflow.gluon.load_model(model_path, ctx.cpu())
+    actual = nd.argmax(model_loaded(test_data), axis=1)
+    assert all(expected == actual)
+    # Loading pyfunc model
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
+    test_pyfunc_data = pd.DataFrame(test_data.asnumpy())
+    pyfunc_preds = pyfunc_loaded.predict(test_pyfunc_data)
+    assert all(
+        np.argmax(pyfunc_preds.values, axis=1)
+        == expected.asnumpy())
+
+
+@pytest.mark.large
+def test_model_log_load(gluon_model, model_data, model_path):
+    _, _, test_data = model_data
+    expected = nd.argmax(gluon_model(test_data), axis=1)
+
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.gluon.log_model(gluon_model, artifact_path=artifact_path)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path)
+
+    # Loading Gluon model
+    model_loaded = mlflow.gluon.load_model(model_uri, ctx.cpu())
+    actual = nd.argmax(model_loaded(test_data), axis=1)
+    assert all(expected == actual)
+    # Loading pyfunc model
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_uri)
+    test_pyfunc_data = pd.DataFrame(test_data.asnumpy())
+    pyfunc_preds = pyfunc_loaded.predict(test_pyfunc_data)
+    assert all(
+        np.argmax(pyfunc_preds.values, axis=1)
+        == expected.asnumpy())
+
+
+@pytest.mark.large
+def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
+        gluon_model, model_path, gluon_custom_env):
+    mlflow.gluon.save_model(gluon_model=gluon_model, path=model_path, conda_env=gluon_custom_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+    assert saved_conda_env_path != gluon_custom_env
+
+    with open(gluon_custom_env, "r") as f:
+        gluon_custom_env_parsed = yaml.safe_load(f)
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == gluon_custom_env_parsed
+
+
+@pytest.mark.large
+def test_model_save_accepts_conda_env_as_dict(gluon_model, model_path):
+    conda_env = dict(mlflow.gluon.get_default_conda_env())
+    conda_env["dependencies"].append("pytest")
+    mlflow.gluon.save_model(gluon_model=gluon_model, path=model_path, conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env
+
+
+@pytest.mark.large
+def test_log_model_persists_specified_conda_env_in_mlflow_model_directory(
+        gluon_model, gluon_custom_env):
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.gluon.log_model(
+            gluon_model=gluon_model, artifact_path=artifact_path, conda_env=gluon_custom_env)
+        model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path))
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+    assert saved_conda_env_path != gluon_custom_env
+
+    with open(gluon_custom_env, "r") as f:
+        gluon_custom_env_parsed = yaml.safe_load(f)
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == gluon_custom_env_parsed
+
+
+@pytest.mark.large
+def test_gluon_model_serving_and_scoring_as_pyfunc(gluon_model, model_data):
+    _, _, test_data = model_data
+    expected = nd.argmax(gluon_model(test_data), axis=1)
+
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.gluon.log_model(gluon_model, artifact_path=artifact_path)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path)
+
+    scoring_response = pyfunc_serve_and_score_model(
+        model_uri=model_uri,
+        data=pd.DataFrame(test_data.asnumpy()),
+        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
+    response_values =\
+        pd.read_json(scoring_response.content, orient="records").values.astype(np.float32)
+    assert all(
+        np.argmax(response_values, axis=1)
+        == expected.asnumpy())

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -1,0 +1,129 @@
+import random
+import warnings
+
+import mxnet as mx
+import mxnet.ndarray as nd
+import numpy as np
+import pytest
+from mxnet.gluon import Trainer
+from mxnet.gluon.contrib.estimator import estimator
+from mxnet.gluon.data import Dataset, DataLoader
+from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
+from mxnet.gluon.nn import HybridSequential, Dense
+from mxnet.metric import Accuracy
+
+import mlflow
+import mlflow.gluon
+
+client = mlflow.tracking.MlflowClient()
+
+
+class LogsDataset(Dataset):
+    def __init__(self):
+        self.len = 1000
+
+    def __getitem__(self, idx):
+        return nd.array(np.random.rand(1, 32)), nd.full(1, random.randint(0, 10), dtype="float32")
+
+    def __len__(self):
+        return self.len
+
+
+@pytest.fixture
+def gluon_random_data_run():
+    mlflow.gluon.autolog()
+
+    with mlflow.start_run() as run:
+        data = DataLoader(LogsDataset(), batch_size=128, last_batch="discard")
+        validation = DataLoader(LogsDataset(), batch_size=128, last_batch="discard")
+
+        model = HybridSequential()
+        model.add(Dense(64, activation="relu"))
+        model.add(Dense(64, activation="relu"))
+        model.add(Dense(10))
+        model.initialize()
+        model.hybridize()
+        trainer = Trainer(model.collect_params(), "adam",
+                          optimizer_params={"learning_rate": .001, "epsilon": 1e-07})
+        est = estimator.Estimator(net=model, loss=SoftmaxCrossEntropyLoss(),
+                                  metrics=Accuracy(), trainer=trainer)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            est.fit(data, epochs=3, val_data=validation)
+
+    return client.get_run(run.info.run_id)
+
+
+@pytest.mark.large
+def test_gluon_autolog_logs_expected_data(gluon_random_data_run):
+    data = gluon_random_data_run.data
+    assert "train accuracy" in data.metrics
+    assert "validation accuracy" in data.metrics
+    assert "train softmaxcrossentropyloss" in data.metrics
+    assert "validation softmaxcrossentropyloss" in data.metrics
+    assert "optimizer_name" in data.params
+    assert data.params["optimizer_name"] == "Adam"
+    assert "epsilon" in data.params
+    assert data.params["epsilon"] == "1e-07"
+
+
+@pytest.mark.large
+def test_gluon_autolog_model_can_load_from_artifact(gluon_random_data_run):
+    artifacts = client.list_artifacts(gluon_random_data_run.info.run_id)
+    artifacts = list(map(lambda x: x.path, artifacts))
+    assert "model" in artifacts
+    ctx = mx.cpu()
+    model = mlflow.gluon.load_model("runs:/" + gluon_random_data_run.info.run_id + "/model", ctx)
+    model(nd.array(np.random.rand(1000, 1, 32)))
+
+
+@pytest.mark.large
+def test_autolog_ends_auto_created_run():
+    mlflow.gluon.autolog()
+
+    data = DataLoader(LogsDataset(), batch_size=128, last_batch="discard")
+
+    model = HybridSequential()
+    model.add(Dense(64, activation="relu"))
+    model.add(Dense(64, activation="relu"))
+    model.add(Dense(10))
+    model.initialize()
+    model.hybridize()
+
+    trainer = Trainer(model.collect_params(), "adam",
+                      optimizer_params={"learning_rate": .001, "epsilon": 1e-07})
+    est = estimator.Estimator(net=model, loss=SoftmaxCrossEntropyLoss(),
+                              metrics=Accuracy(), trainer=trainer)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        est.fit(data, epochs=3)
+
+    assert mlflow.active_run() is None
+
+
+@pytest.mark.large
+def test_autolog_persists_manually_created_run():
+    mlflow.gluon.autolog()
+
+    data = DataLoader(LogsDataset(), batch_size=128, last_batch="discard")
+
+    with mlflow.start_run() as run:
+
+        model = HybridSequential()
+        model.add(Dense(64, activation="relu"))
+        model.add(Dense(64, activation="relu"))
+        model.add(Dense(10))
+        model.initialize()
+        model.hybridize()
+        trainer = Trainer(model.collect_params(), "adam",
+                          optimizer_params={"learning_rate": .001, "epsilon": 1e-07})
+        est = estimator.Estimator(net=model, loss=SoftmaxCrossEntropyLoss(),
+                                  metrics=Accuracy(), trainer=trainer)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            est.fit(data, epochs=3)
+
+        assert mlflow.active_run().info.run_id == run.info.run_id

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -11,6 +11,7 @@ onnx==1.4.1; python_version >= "3.0"
 onnxmltools==1.4.0; python_version >= "3.0"
 onnxruntime==0.3.0; python_version >= "3.0"
 mleap==0.8.1
+mxnet==1.5.0
 pandas<=0.23.4
 pyarrow==0.12.1
 pyspark==2.4.0

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -20,7 +20,8 @@ export MLFLOW_HOME=$(pwd)
 pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
   --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/azureml --ignore=tests/onnx \
-  --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog
+  --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore=tests/gluon \
+  --ignore=tests/gluon_autolog
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
 pytest --verbose tests/examples --large
@@ -41,4 +42,6 @@ pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
 pytest --verbose tests/keras --large
 pytest --verbose tests/keras_autolog --large
+pytest --verbose tests/gluon --large
+pytest --verbose tests/gluon_autolog --large
 test $err = 0

--- a/travis/small-requirements.txt
+++ b/travis/small-requirements.txt
@@ -5,6 +5,7 @@ botocore==1.12.84  # pinned for moto
 boto3==1.9.84      # pinned for moto
 mock==2.0.0
 moto==1.3.7
+mxnet==1.5.0
 pandas<=0.23.4
 scikit-learn==0.20.2
 scipy==1.2.1


### PR DESCRIPTION
* Add Gluon autolog capabilities for simple fitting.

MXNet's Gluon API features a simple and direct fir method on an estimator. This is similar to Keras.
This is the autologer for it.

* Remove Python type hints to support legacy Python 2.
Add MXnet as a dependency to small requirements instead of large.
Make the computing context an argument to load model.

* Fix a lint error with a line being too long

* Add validation metric test

* Require MXNet bot for large and small requirements (not sure this is correct)

* Add a missing documentation reference.

* Log estimator parameters at the begining of training as opposed to at the end.

* Log the network at the end, after training, as it should

* A lint error. By now, the commit are sure to be squashed.

* Add Gluon pyfunc functionality

* Tests added, and conda env

* Run the Gluon tests just like the other DL frameworks.

* Fix conda envs

* Small fix

* Enable the ESLint comma-dangle rule (#2069)

* Enable comma-dangle

* Apply lint:fix

* Fix artifact image viewer to support animated GIF (#2070)

* Update ShowArtifactImageView to handle gif

* Remove imageContainer

* Refactor and add comments

* Add alt text

* Add test

* Show current tag value on edit (#2105)

* Add and fix tests

* Lint

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
