### PR TITLE
hdfs archiver set empty path when run has no artifact

### DIFF
--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -142,8 +142,7 @@ def archive_hdfs_artifacts(run_id):
     _logger.debug("Update database: artifact_uri for run (run_id = %s) to %s",
                   run_id, new_artifact_path)
     store.update_artifacts_location(run_id, new_artifact_path)
-    if new_artifact_path:
-        remove_folder(artifact_uri)
+    remove_folder(artifact_uri)
 
 
 if __name__ == '__main__':

--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -142,7 +142,8 @@ def archive_hdfs_artifacts(run_id):
     _logger.debug("Update database: artifact_uri for run (run_id = %s) to %s",
                   run_id, new_artifact_path)
     store.update_artifacts_location(run_id, new_artifact_path)
-    remove_folder(artifact_uri)
+    if new_artifact_path:
+        remove_folder(artifact_uri)
 
 
 if __name__ == '__main__':

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -270,8 +270,10 @@ def archive_artifacts(hdfs_artifact_repository, dest_path, archive_name):
     # clean existing archive if exists
     remove_folder(dest_path + '/' + archive_name)
 
-    list_artifacts = " ".join(
-        [file_info.path for file_info in hdfs_artifact_repository.list_artifacts()])
+    files_info = hdfs_artifact_repository.list_artifacts()
+    if not files_info:
+        return ""
+    list_artifacts = " ".join([file_info.path for file_info in files_info])
     cmd = "hadoop archive -archiveName {archive_name} -p {artifact_path} "\
         "{list_artifacts} {dest_path}".format(
             archive_name=archive_name, artifact_path=hdfs_artifact_repository.path,

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -246,4 +246,3 @@ def test_archive_artifacts_empty_run(mock_remove_folder):
     expected_har_path = ""
     assert expected_har_path == archive_artifacts(
         mock_hdfs_artifact_repo, run_folder, "artifacts.har")
-

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -234,3 +234,16 @@ def test_archive_artifacts(mock_remove_folder, mock_checkoutput):
         mock_hdfs_artifact_repo, run_folder, "artifacts.har")
     mock_remove_folder.assert_called_once()
     mock_checkoutput.assert_called_once_with(shlex.split(expected_package_cmd))
+
+
+@mock.patch("mlflow.store.artifact.hdfs_artifact_repo.remove_folder")
+def test_archive_artifacts_empty_run(mock_remove_folder):
+    run_folder = "hdfs://root/user/j.doe/experiment/1/xxxyyyyyy"
+    mock_hdfs_artifact_repo = mock.Mock(spec=HdfsArtifactRepository)
+    mock_hdfs_artifact_repo.list_artifacts.return_value = []
+    mock_hdfs_artifact_repo.host = "root"
+    mock_hdfs_artifact_repo.path = "{run_folder}/artifacts".format(run_folder=run_folder)
+    expected_har_path = ""
+    assert expected_har_path == archive_artifacts(
+        mock_hdfs_artifact_repo, run_folder, "artifacts.har")
+

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -246,3 +246,4 @@ def test_archive_artifacts_empty_run(mock_remove_folder):
     expected_har_path = ""
     assert expected_har_path == archive_artifacts(
         mock_hdfs_artifact_repo, run_folder, "artifacts.har")
+    mock_remove_folder.assert_called_once()


### PR DESCRIPTION
… artifact in run

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
