### PR TITLE
[criteo-master] fix sqlalchemy sorting that was filtering some runs 

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -603,8 +603,10 @@ class SqlAlchemyStore(AbstractStore):
             parsed_orderby, sorting_joins = _get_orderby_clauses(order_by, session)
 
             query = session.query(SqlRun)
-            for j in _get_sqlalchemy_filter_clauses(parsed_filters, session) + sorting_joins:
+            for j in _get_sqlalchemy_filter_clauses(parsed_filters, session):
                 query = query.join(j)
+            for j in sorting_joins:
+                query = query.outerjoin(j)
 
             offset = SearchUtils.parse_start_offset_from_page_token(page_token)
             queried_runs = query.distinct() \

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1492,6 +1492,28 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                              ViewType.ALL, max_results=5)
         assert len(run_results) == 1  # 2 runs on previous request, 1 of which has a 0 pkey_0 value
 
+    def test_search_runs_keep_all_runs_when_sorting(self):
+        experiment_id = self.store.create_experiment('test_experiment1')
+
+        r1 = self.store.create_run(
+            experiment_id=experiment_id,
+            start_time=0,
+            tags=(),
+            user_id='Me').info.run_uuid
+        r2 = self.store.create_run(
+            experiment_id=experiment_id,
+            start_time=0,
+            tags=(),
+            user_id='Me').info.run_uuid
+        self.store.set_tag(r1, RunTag(key="t1", value="1"))
+        self.store.set_tag(r1, RunTag(key="t2", value="1"))
+        self.store.set_tag(r2, RunTag(key="t2", value="1"))
+
+        run_results = self.store.search_runs([experiment_id],
+                                             None,
+                                             ViewType.ALL, max_results=1000, order_by=["tag.t1"])
+        assert len(run_results) == 2
+
     def test_get_attribute_name(self):
         assert(models.SqlRun.get_attribute_name("artifact_uri") == "artifact_uri")
         assert(models.SqlRun.get_attribute_name("status") == "status")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix a bug that was causing sorting of runs to filter out runs without value for a metric/tag/param
in sql alchemy store

## How is this patch tested?

I added a test for this case in the sql alchemy store

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix sorting filtering in sql alchemy store

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [x] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
