### PR TITLE
Added optional prometheus exporter (#2097)

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -237,8 +237,12 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Additional command line options forwarded to gunicorn processes.")
 @click.option("--waitress-opts", default=None,
               help="Additional command line options for waitress-serve.")
+@click.option("--expose-prometheus", default=None,
+              help="Path to the directory where metrics will be stored. If the directory"
+                   "doesn't exist, it will be created."
+                   "Activate prometheus exporter to expose metrics on /metrics endpoint.")
 def server(backend_store_uri, default_artifact_root, host, port,
-           workers, static_prefix, gunicorn_opts, waitress_opts):
+           workers, static_prefix, gunicorn_opts, waitress_opts, expose_prometheus):
     """
     Run the MLflow tracking server.
 
@@ -271,7 +275,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
 
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port,
-                    static_prefix, workers, gunicorn_opts, waitress_opts)
+                    static_prefix, workers, gunicorn_opts, waitress_opts, expose_prometheus)
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -1,0 +1,28 @@
+from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
+from flask import request
+
+
+def activate_prometheus_exporter(app):
+    metrics = GunicornInternalPrometheusMetrics(app, export_defaults=False)
+
+    endpoint = app.view_functions
+    histogram = metrics.histogram('mlflow_requests_by_status_and_path',
+                                  'Request latencies and count by status and path',
+                                  labels={'status': lambda r: r.status_code,
+                                          'path': lambda: change_path_for_metric(request.path)})
+    for func_name, func in endpoint.items():
+        if func_name in ["_search_runs", "_log_metric", "_log_param", "_set_tag", "_create_run"]:
+            app.view_functions[func_name] = histogram(func)
+
+    return app
+
+
+def change_path_for_metric(path):
+    """
+    Replace the '/' in the metric path by '_' so grafana can correctly use it.
+    :param path: path of the metric (example: runs/search)
+    :return: path with '_' instead of '/'
+    """
+    if 'mlflow/' in path:
+        path = path.split('mlflow/')[-1]
+    return path.replace('/', '_')

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'sqlparse',
         'sqlalchemy',
         'gorilla',
+        'prometheus-flask-exporter',
     ],
     extras_require={
         'extras':[


### PR DESCRIPTION
* Added optionnal prometheus exporter

* Added prometheus-flask-exporter in requirements in setup.py

* Fix failing test

* Changed cli option to --expose-prometheus

* Automatically setup prometheus_multiproc_dir environment variable and automatically create metric directory

* Update creation of metrics dir to support python 2

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
