### PR TITLE
Update compatibility with later versions of pyarrow (up to 0.17.0)

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -652,13 +652,7 @@ There are also two ways to authenticate to HDFS:
 Most of the cluster contest settings are read from ``hdfs-site.xml`` accessed by the HDFS native
 driver using the ``CLASSPATH`` environment variable.
 
-Optionally you can select a different version of the HDFS driver library using:
-
-.. code-block:: bash
-
-  export MLFLOW_HDFS_DRIVER=libhdfs3
-
-The default driver is ``libhdfs``.
+The used HDFS driver is ``libhdfs``.
 
 
 Networking

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -891,7 +891,6 @@ def _get_hdfs_artifact_cmd_and_envs(artifact_repo):
     # pylint: disable=unused-argument
     cmds = []
     envs = {
-        "MLFLOW_HDFS_DRIVER": os.environ.get("MLFLOW_HDFS_DRIVER"),
         "MLFLOW_KERBEROS_TICKET_CACHE": os.environ.get("MLFLOW_KERBEROS_TICKET_CACHE"),
         "MLFLOW_KERBEROS_USER": os.environ.get("MLFLOW_KERBEROS_USER"),
         "MLFLOW_PYARROW_EXTRA_CONF": os.environ.get("MLFLOW_PYARROW_EXTRA_CONF")

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -178,27 +178,18 @@ def hdfs_system(scheme, host, port):
     """
     import pyarrow as pa
 
-    if host and host.startswith("har://"):
-        _logger.info(
-            "Hadoop archive can be open only by libhdfs. Ignoring MLFLOW_HDFS_DRIVER setting.")
-        driver = "libhdfs"
-    else:
-        driver = os.getenv('MLFLOW_HDFS_DRIVER') or 'libhdfs'
     kerb_ticket = os.getenv('MLFLOW_KERBEROS_TICKET_CACHE')
     kerberos_user = os.getenv('MLFLOW_KERBEROS_USER')
     extra_conf = _parse_extra_conf(os.getenv('MLFLOW_PYARROW_EXTRA_CONF'))
 
-    if scheme == "viewfs":
-        if driver == "libhdfs":
-            host = scheme + "://" + host
-        else:
-            _logger.warning("viewfs://namenode resolves to hdfs://namenode"
-                            " with hdfs3 driver.")
+    if host:
+        host = scheme + "://" + host
+    else:
+        host = 'default'
 
-    connected = pa.hdfs.connect(host=host or 'default',
+    connected = pa.hdfs.connect(host=host,
                                 port=port or 0,
                                 user=kerberos_user,
-                                driver=driver,
                                 kerb_ticket=kerb_ticket,
                                 extra_conf=extra_conf)
     yield connected

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -204,7 +204,6 @@ def test_docker_gcs_artifact_cmd_and_envs_from_home():
 
 def test_docker_hdfs_artifact_cmd_and_envs_from_home():
     mock_env = {
-        "MLFLOW_HDFS_DRIVER": "mock_libhdfs",
         "MLFLOW_KERBEROS_TICKET_CACHE": "/mock_ticket_cache",
         "MLFLOW_KERBEROS_USER": "mock_krb_user",
         "MLFLOW_PYARROW_EXTRA_CONF": "mock_pyarrow_extra_conf"

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -22,10 +22,7 @@ types = [np.int32, np.int, np.str, np.float32, np.double]
 
 
 def score_model_as_udf(model_uri, pandas_df, result_type="double"):
-    spark = pyspark.sql.SparkSession.builder\
-        .config(key="spark.python.worker.reuse", value=True)\
-        .master("local-cluster[2, 1, 1024]")\
-        .getOrCreate()
+    spark = get_spark_session(pyspark.SparkConf())
     spark_df = spark.createDataFrame(pandas_df)
     pyfunc_udf = spark_udf(spark=spark, model_uri=model_uri, result_type=result_type)
     new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
@@ -52,12 +49,19 @@ def configure_environment():
     os.environ["PYSPARK_PYTHON"] = sys.executable
 
 
-@pytest.fixture
-def spark():
+def get_spark_session(conf):
+    os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
+    conf.set(key="spark_session.python.worker.reuse", value=True)
     return pyspark.sql.SparkSession.builder\
-        .config(key="spark.python.worker.reuse", value=True)\
+        .config(conf=conf)\
         .master("local-cluster[2, 1, 1024]")\
         .getOrCreate()
+
+
+@pytest.fixture
+def spark():
+    conf = pyspark.SparkConf()
+    return get_spark_session(conf)
 
 
 @pytest.fixture

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -30,7 +30,7 @@ from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 
 from tests.helper_functions import score_model_in_sagemaker_docker_container
-from tests.pyfunc.test_spark import score_model_as_udf
+from tests.pyfunc.test_spark import score_model_as_udf, get_spark_session
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
@@ -60,14 +60,10 @@ def spark_context():
     conf.set(key="spark.jars.packages",
              value='ml.combust.mleap:mleap-spark-base_2.11:0.12.0,'
                    'ml.combust.mleap:mleap-spark_2.11:0.12.0')
-    conf.set(key="spark_session.python.worker.reuse", value=True)
     max_tries = 3
     for num_tries in range(max_tries):
         try:
-            spark = pyspark.sql.SparkSession.builder\
-                .config(conf=conf)\
-                .master("local-cluster[2, 1, 1024]")\
-                .getOrCreate()
+            spark = get_spark_session(conf)
             return spark.sparkContext
         except Exception as e:
             if num_tries >= max_tries - 1:

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -27,8 +27,8 @@ def test_log_artifact(hdfs_system_mock):
 
         repo.log_artifact(local_file, 'more_path/some')
 
-        hdfs_system_mock.assert_called_once_with(driver='libhdfs', extra_conf=None,
-                                                 host='host_name',
+        hdfs_system_mock.assert_called_once_with(extra_conf=None,
+                                                 host='hdfs://host_name',
                                                  kerb_ticket=None, port=8020,
                                                  user=None)
 
@@ -40,13 +40,7 @@ def test_log_artifact(hdfs_system_mock):
 
 
 @mock.patch('pyarrow.hdfs.HadoopFileSystem')
-@pytest.mark.parametrize("driver,expected_host",
-                         [("libhdfs",
-                           "viewfs://host_name"),
-                          ("libhdfs3",
-                           "host_name")])
-def test_log_artifact_viewfs(hdfs_system_mock, driver, expected_host):
-    os.environ['MLFLOW_HDFS_DRIVER'] = driver
+def test_log_artifact_viewfs(hdfs_system_mock):
     repo = HdfsArtifactRepository('viewfs://host_name/mypath')
 
     with TempDir() as tmp_dir:
@@ -56,8 +50,8 @@ def test_log_artifact_viewfs(hdfs_system_mock, driver, expected_host):
 
         repo.log_artifact(local_file, 'more_path/some')
 
-        hdfs_system_mock.assert_called_once_with(driver=driver, extra_conf=None,
-                                                 host=expected_host,
+        hdfs_system_mock.assert_called_once_with(extra_conf=None,
+                                                 host="viewfs://host_name",
                                                  kerb_ticket=None, port=0,
                                                  user=None)
 
@@ -74,7 +68,6 @@ def test_log_artifact_with_kerberos_setup(hdfs_system_mock):
         pytest.skip()
     os.environ['MLFLOW_KERBEROS_TICKET_CACHE'] = '/tmp/krb5cc_22222222'
     os.environ['MLFLOW_KERBEROS_USER'] = 'some_kerberos_user'
-    os.environ['MLFLOW_HDFS_DRIVER'] = 'libhdfs3'
 
     repo = HdfsArtifactRepository('hdfs:///some/maybe/path')
 
@@ -84,7 +77,7 @@ def test_log_artifact_with_kerberos_setup(hdfs_system_mock):
 
         repo.log_artifact(tmp_local_file.name, 'test_hdfs/some/path')
 
-        hdfs_system_mock.assert_called_once_with(driver='libhdfs3', extra_conf=None,
+        hdfs_system_mock.assert_called_once_with(extra_conf=None,
                                                  host='default',
                                                  kerb_ticket='/tmp/krb5cc_22222222', port=0,
                                                  user='some_kerberos_user')
@@ -107,7 +100,6 @@ def test_log_artifact_with_invalid_local_dir(_):
 def test_log_artifacts(hdfs_system_mock):
     os.environ['MLFLOW_KERBEROS_TICKET_CACHE'] = '/tmp/krb5cc_22222222'
     os.environ['MLFLOW_KERBEROS_USER'] = 'some_kerberos_user'
-    os.environ['MLFLOW_HDFS_DRIVER'] = 'libhdfs3'
 
     repo = HdfsArtifactRepository('hdfs:///some_path/maybe/path')
 
@@ -121,7 +113,7 @@ def test_log_artifacts(hdfs_system_mock):
 
         repo.log_artifacts(root_dir._path)
 
-        hdfs_system_mock.assert_called_once_with(driver='libhdfs3', extra_conf=None,
+        hdfs_system_mock.assert_called_once_with(extra_conf=None,
                                                  host='default',
                                                  kerb_ticket='/tmp/krb5cc_22222222', port=0,
                                                  user='some_kerberos_user')

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -12,7 +12,7 @@ onnxruntime==0.3.0;
 mleap==0.8.1
 mxnet==1.5.0
 pandas<=0.23.4
-pyarrow==0.12.1
+pyarrow==0.17.0
 pyspark==2.4.0
 pytest==3.2.1
 pytest-cov==2.6.0

--- a/travis/lint-requirements.txt
+++ b/travis/lint-requirements.txt
@@ -1,5 +1,5 @@
 prospector[with_pyroma]==0.12.7
 pep8==1.7.1
-pyarrow==0.12.1
+pyarrow==0.17.0
 pylint==1.8.2
 rstcheck==3.2

--- a/travis/small-requirements.txt
+++ b/travis/small-requirements.txt
@@ -9,7 +9,7 @@ mxnet==1.5.0
 pandas<=0.23.4
 scikit-learn==0.20.2
 scipy==1.2.1
-pyarrow==0.12.1
+pyarrow==0.17.0
 pysftp==0.2.9
 attrdict==2.0.0
 cloudpickle==0.8.0


### PR DESCRIPTION
- Remove hdfs3 support because current code fails with pyarrow 0.17.0
"TypeError: connect() got an unexpected keyword argument 'driver'"

- Related arrow commit where hdfs3 is deactivated
(see apache/arrow@4e53749)

- Setting ARROW_PRE_0_15_IPC_FORMAT=1 in tests for spark udf:
https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html#compatibiliy-setting-for-pyarrow--0150-and-spark-23x-24x

- Even though the tests have been updated it still keeps working with older pyarrow versions, driver will just take 'libhdfs' as default arg

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
