### PR TITLE
Criteo authentication - only get token on 401 error. Correctly handle…

### DIFF
--- a/mlflow/tracking/criteo_authentication.py
+++ b/mlflow/tracking/criteo_authentication.py
@@ -22,11 +22,11 @@ def get_tracking_server_uri() -> str:
 # pylint: disable=unused-argument
 def _get_authenticated_rest_store(store_uri: str, **_: Any) -> RestStore:
     def _return_token(force_refresh_token: bool = False) -> MlflowHostCreds:
-        if _TRACKING_TOKEN_ENV_VAR not in os.environ or force_refresh_token:
+        if force_refresh_token:
             token = _generate_jwt_from_kerberos().replace("Bearer ", "")
             os.environ[_TRACKING_TOKEN_ENV_VAR] = token
         return MlflowHostCreds(
-            host=get_tracking_server_uri(), token=os.environ[_TRACKING_TOKEN_ENV_VAR]
+            host=get_tracking_server_uri(), token=os.getenv(_TRACKING_TOKEN_ENV_VAR, "")
         )
 
     return RestStore(_return_token)
@@ -42,6 +42,8 @@ def _generate_jwt_from_kerberos():
     else:
         jtc_url = "https://jtc.preprod.crto.in/spnego/generate/jwt"
     jtc_request = requests.get(jtc_url, auth=auth)
+    if jtc_request.status_code != 200:
+        raise Exception(f"Failed to get a token from the jtc. {jtc_request.text}.")
     return jtc_request.json()["jwt"]
 
 

--- a/mlflow/tracking/criteo_authentication.py
+++ b/mlflow/tracking/criteo_authentication.py
@@ -43,7 +43,7 @@ def _generate_jwt_from_kerberos():
         jtc_url = "https://jtc.preprod.crto.in/spnego/generate/jwt"
     jtc_request = requests.get(jtc_url, auth=auth)
     if jtc_request.status_code != 200:
-        raise Exception(f"Failed to get a token from the jtc. {jtc_request.text}.")
+        raise Exception("Failed to get a token from the jtc. " + jtc_request.text)
     return jtc_request.json()["jwt"]
 
 

--- a/tests/tracking/test_criteo_authentication.py
+++ b/tests/tracking/test_criteo_authentication.py
@@ -17,6 +17,7 @@ from mlflow.tracking._tracking_service.utils import (
     _tracking_store_registry,
     _TRACKING_TOKEN_ENV_VAR,
 )
+from mlflow.exceptions import RestException
 
 
 @responses.activate
@@ -43,7 +44,7 @@ def test_authenticated_client_put_token_in_header(jtc_patch):
     # so the rest store will raise a RestException
     try:
         mlflow.get_experiment("0")
-    except Exception:
+    except RestException:
         pass
     # calls[1] because the second call should have the token (we refresh after the first 401)
     assert responses.calls[1].request.headers["Authorization"] == "Bearer my-token"


### PR DESCRIPTION
… errors when the jtc fails to return a token.

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
