### PR TITLE
Backport 7908

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   check-comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'autoformat') }}
     outputs:
       matched: ${{ steps.check-comment.outputs.result }}
@@ -39,7 +39,7 @@ jobs:
             return await autoformat.createStatus(context, github, core);
 
   check-diff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: check-comment
     if: ${{ needs.check-comment.outputs.matched == 'true' }}
     outputs:
@@ -65,7 +65,7 @@ jobs:
 
   python:
     # Generate a patch to format python files.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [check-comment, check-diff]
     if: ${{ needs.check-diff.outputs.py_changed == 'true' }}
     outputs:
@@ -100,7 +100,7 @@ jobs:
 
   ui:
     # Generate a patch to format files for MLflow UI.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [check-comment, check-diff]
     if: ${{ needs.check-diff.outputs.ui_changed == 'true' }}
     outputs:
@@ -139,7 +139,7 @@ jobs:
 
   apply-patches:
     # Apply the patches and commit changes to the PR branch.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [check-comment, check-diff, python, ui]
     if: |
       always() &&
@@ -178,7 +178,7 @@ jobs:
           git push
 
   update-status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [check-comment, check-diff, python, ui, apply-patches]
     if: ${{ always() && needs.check-comment.outputs.matched == 'true' }}
     steps:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -41,7 +41,7 @@ defaults:
 
 jobs:
   set-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       is_matrix_empty: ${{ steps.set-matrix.outputs.is_matrix_empty }}
@@ -94,7 +94,7 @@ jobs:
   test:
     needs: set-matrix
     if: ${{ needs.set-matrix.outputs.is_matrix_empty == 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Increase available disk space
@@ -74,7 +74,7 @@ jobs:
         df -h
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Increase available disk space

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   labeling:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: harupy/auto-labeling@master

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
@@ -48,7 +48,7 @@ jobs:
       run: |
         ./dev/lint.sh
   r:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: mlflow/R/mlflow
@@ -98,7 +98,7 @@ jobs:
   # The python skinny tests cover the subset of mlflow functionality
   # while also verifying certain dependencies are omitted.
   python-skinny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
@@ -115,7 +115,7 @@ jobs:
         ./dev/run-python-skinny-tests.sh
 
   python-small:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
@@ -131,7 +131,7 @@ jobs:
         ./dev/run-small-python-tests.sh
 
   python-large:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Increase available disk space
@@ -191,7 +191,7 @@ jobs:
         ./dev/test-anaconda-compatibility.sh "anaconda3:2019.03"
 
   java:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/setup-python
@@ -213,7 +213,7 @@ jobs:
         mvn clean package -q
 
   js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: mlflow/server/js
@@ -237,7 +237,7 @@ jobs:
         npm run test
 
   protos:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Test building Docker image
@@ -256,7 +256,7 @@ jobs:
         ./dev/test-generate-protos.sh
 
   flavors:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Increase available disk space
@@ -289,7 +289,7 @@ jobs:
   # It takes 9 ~ 10 minutes to run tests in `tests/models`. To make CI finish faster,
   # run these tests in a separate job.
   models:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-python
@@ -314,7 +314,7 @@ jobs:
           pytest tests/models --large
 
   import:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -334,7 +334,7 @@ jobs:
           fi
 
   sagemaker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup-python

--- a/.github/workflows/notify-dco-failure.yml
+++ b/.github/workflows/notify-dco-failure.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/github-script@v4

--- a/.github/workflows/release-note-category.yml
+++ b/.github/workflows/release-note-category.yml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Validate

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         type: ["full", "skinny"]

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
@@ -33,10 +33,9 @@ public class ModelRegistryMlflowClientTest {
     private final TestClientProvider testClientProvider = new TestClientProvider();
 
     private MlflowClient client;
+    private String source;
 
     private String modelName;
-    private File tempDir;
-    private File tempFile;
 
     private static final String content = "Hello, Worldz!";
 
@@ -59,16 +58,17 @@ public class ModelRegistryMlflowClientTest {
 
         RunInfo runCreated = client.createRun(expId);
         String runId = runCreated.getRunUuid();
+        source = String.format("runs:/%s/model", runId);
 
-        tempDir = Files.createTempDirectory("tempDir").toFile();
-        tempFile = Files.createTempFile(tempDir.toPath(), "file", ".txt").toFile();
+        File tempDir = Files.createTempDirectory("tempDir").toFile();
+        File tempFile = Files.createTempFile(tempDir.toPath(), "file", ".txt").toFile();
 
         FileUtils.writeStringToFile(tempFile, content, StandardCharsets.UTF_8);
         client.sendPost("registered-models/create",
                 mapper.makeCreateModel(modelName));
 
         client.sendPost("model-versions/create",
-                mapper.makeCreateModelVersion(modelName, runId, tempDir.getAbsolutePath()));
+                mapper.makeCreateModelVersion(modelName, runId, String.format("runs:/%s/model", runId)));
     }
 
     @AfterTest
@@ -102,7 +102,7 @@ public class ModelRegistryMlflowClientTest {
     @Test
     public void testGetModelVersionDownloadUri() {
         String downloadUri = client.getModelVersionDownloadUri(modelName, "1");
-        Assert.assertEquals(tempDir.getAbsolutePath(), downloadUri);
+        Assert.assertEquals(source, downloadUri);
     }
 
     @Test

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -79,6 +79,7 @@ from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.validation import _validate_batch_log_api_req
 from mlflow.utils.string_utils import is_string_type
+from mlflow.utils.uri import is_local_uri
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 
 _logger = logging.getLogger(__name__)
@@ -793,6 +794,12 @@ def _delete_registered_model_tag():
 @_disable_if_artifacts_only
 def _create_model_version():
     request_message = _get_request_message(CreateModelVersion())
+    if is_local_uri(request_message.source):
+        raise MlflowException(
+            f"Model version source cannot be a local path: '{request_message.source}'",
+            INVALID_PARAMETER_VALUE,
+        )
+
     model_version = _get_model_registry_store().create_model_version(
         name=request_message.name,
         source=request_message.source,

--- a/mlflow/utils/os.py
+++ b/mlflow/utils/os.py
@@ -1,0 +1,8 @@
+import os
+
+
+def is_windows():
+    """
+    :return: Returns true if the local system/OS name is Windows.
+    """
+    return os.name == "nt"

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -470,7 +470,7 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
     run_link = "localhost:5000/path/to/run"
     mock_get_request_message.return_value = CreateModelVersion(
         name="model_1",
-        source="A/B",
+        source=f"runs:/{run_id}",
         run_id=run_id,
         run_link=run_link,
         tags=[tag.to_proto() for tag in tags],
@@ -482,7 +482,7 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
     resp = _create_model_version()
     _, args = mock_model_registry_store.create_model_version.call_args
     assert args["name"] == "model_1"
-    assert args["source"] == "A/B"
+    assert args["source"] == f"runs:/{run_id}"
     assert args["run_id"] == run_id
     assert {tag.key: tag.value for tag in args["tags"]} == {tag.key: tag.value for tag in tags}
     assert args["run_link"] == run_link

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -17,6 +17,7 @@ from mlflow.utils.uri import (
     is_http_uri,
     is_local_uri,
     is_valid_dbfs_uri,
+    is_windows,
     remove_databricks_profile_info_from_artifact_uri,
     dbfs_hdfs_uri_to_fuse_path,
 )
@@ -132,7 +133,7 @@ def test_construct_run_url_errors(hostname, experiment_id, run_id, workspace_id)
         construct_run_url(hostname, experiment_id, run_id, workspace_id)
 
 
-def test_uri_types():
+def test_is_local_uri():
     assert is_local_uri("mlruns")
     assert is_local_uri("./mlruns")
     assert is_local_uri("file:///foo/mlruns")
@@ -143,12 +144,21 @@ def test_uri_types():
     assert not is_local_uri("databricks:whatever")
     assert not is_local_uri("databricks://whatever")
 
+@pytest.mark.skipif(not is_windows(), reason="Windows-only test")
+def test_is_local_uri_windows():
+    assert is_local_uri("C:\\foo\\mlruns")
+    assert is_local_uri("C:/foo/mlruns")
+    assert is_local_uri("file:///C:\\foo\\mlruns")
+
+
+def test_is_databricks_uri():
     assert is_databricks_uri("databricks")
     assert is_databricks_uri("databricks:whatever")
     assert is_databricks_uri("databricks://whatever")
     assert not is_databricks_uri("mlruns")
     assert not is_databricks_uri("http://whatever")
 
+def test_is_http_uri():
     assert is_http_uri("http://whatever")
     assert is_http_uri("https://whatever")
     assert not is_http_uri("file://whatever")


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [X ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [X ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
